### PR TITLE
fix: text not printed

### DIFF
--- a/src/components/Wallet/TxHistory/index.tsx
+++ b/src/components/Wallet/TxHistory/index.tsx
@@ -154,7 +154,10 @@ const TxHistory: FC<any> = ({
 
             {txs?.data?.length === 0 && (
                 <Box>
-                    <Typography fontStyle="italic" textAlign="center">
+                    <Typography
+                        fontStyle="italic"
+                        textAlign="center"
+                        color="text.secondary">
                         Tidak ada data transaksi
                     </Typography>
                 </Box>


### PR DESCRIPTION
This pull request includes a small change to the `TxHistory` component in the `src/components/Wallet/TxHistory/index.tsx` file. The change improves the styling of the message displayed when there are no transactions by adding a secondary text color to the `Typography` component.

Styling improvement:

* [`src/components/Wallet/TxHistory/index.tsx`](diffhunk://#diff-1b1d701378ce64f8fafd7afbcdfc3b6978a005606dc2721db695b189dd8a473aL157-R160): Added `color="text.secondary"` to the `Typography` component to enhance the appearance of the "no transaction data" message.