### PR TITLE
disable sort by user name

### DIFF
--- a/src/pages/farm-input-product-sales.tsx
+++ b/src/pages/farm-input-product-sales.tsx
@@ -256,6 +256,7 @@ const DATATABLE_COLUMNS: MUIDataTableColumn[] = [
         name: 'buyerUser.name',
         label: 'Pengguna',
         options: {
+            sort: false,
             customBodyRenderLite: dataIndex => {
                 const data = getRowData(dataIndex)
                 if (!data || !data.buyer_user) return ''


### PR DESCRIPTION
Fixes #259

unfornutaly, yajra's query is priority the sort column first, and when the related data is null than other relations also returning null