### PR TITLE
Fix role value synchronization issue

### DIFF
--- a/src/enums/Role.ts
+++ b/src/enums/Role.ts
@@ -16,8 +16,8 @@ enum Role {
     FARM_INPUT_MANAGER = 'farm inputs manager',
     FARM_INPUT_WAREHOUSE_MANAGER = 'farm input warehouse manager',
     FARM_INPUT_PURCHASER = 'farm inputs purchaser',
-    FARM_INPUT_SALES_MUAI_WAREHOUSE = 'farm inputs sales - muai warehouse',
-    FARM_INPUT_SALES_PULAU_PINANG_WAREHOUSE = 'farm inputs sales - pulau pinang warehouse',
+    FARM_INPUT_SALES_MUAI_WAREHOUSE = 'farm input sales - muai warehouse',
+    FARM_INPUT_SALES_PULAU_PINANG_WAREHOUSE = 'farm input sales - pulau pinang warehouse',
 
     // cash
     CASH_MANAGER = 'cashes manager',


### PR DESCRIPTION
This pull request fixes an issue where the roles value was not in sync with the database/backend. The enum values for 'farm input sales - muai warehouse' and 'farm input sales - pulau pinang warehouse' were incorrect and have been corrected. This ensures that the roles are correctly synchronized with the database/backend.

fix #295

ref: https://github.com/sensasi-apps/ekbs-laravel/pull/217/commits/5ddfcc354e695f4714a645c51098e110b681fc40