### PR TITLE
Improve cost comparison precision in ProductPurchaseForm

### DIFF
--- a/src/components/pages/farm-inputs/product-purchases/Form.tsx
+++ b/src/components/pages/farm-inputs/product-purchases/Form.tsx
@@ -80,8 +80,8 @@ const ProductPurchaseForm = memo(function ProductPurchaseForm({
         ) ?? 0
 
     const isCostMatch =
-        parseFloat(totalRpCost.toString()) ===
-        parseFloat(totalRpCostItem.toString())
+        totalRpCost === totalRpCostItem ||
+        Math.abs(totalRpCost - totalRpCostItem) < 0.0001
 
     return (
         <FormikForm


### PR DESCRIPTION
fix #314

This pull request fixes an issue in the `ProductPurchaseForm` component where the cost comparison was not precise enough. The previous implementation used `parseFloat` to compare the total costs, which could result in incorrect comparisons due to floating-point precision errors. This PR updates the comparison logic to use a more precise approach, ensuring that the total costs are compared accurately.