### PR TITLE
Refactor getUserHashKey function and migrate user hash keys

### DIFF
--- a/src/providers/Auth/functions/getUserHashKey.ts
+++ b/src/providers/Auth/functions/getUserHashKey.ts
@@ -1,5 +1,30 @@
 import { sha3_256 } from 'js-sha3'
 
 export function getUserHashKey(email: string, password: string) {
+    migrateUserHasKeyFromV1(email, password)
+
+    return getUserHashKeyMainFn(email, password)
+}
+
+function getUserHashKeyMainFn(email: string, password: string) {
+    return sha3_256(email + password)
+}
+
+function migrateUserHasKeyFromV1(email: string, password: string) {
+    const oldHashKey = getUserHashKeyV1(email, password)
+    const newHashKey = getUserHashKeyMainFn(email, password)
+
+    const storedAuthInfoJson = localStorage.getItem(oldHashKey)
+
+    if (storedAuthInfoJson) {
+        localStorage.setItem(newHashKey, storedAuthInfoJson)
+        localStorage.removeItem(oldHashKey)
+    }
+}
+
+/**
+ * @deprecated
+ */
+function getUserHashKeyV1(email: string, password: string) {
     return sha3_256(email.split('@')[0] + password)
 }


### PR DESCRIPTION
This commit refactors the getUserHashKey function in the Auth provider. It introduces a new function, getUserHashKeyMainFn, which calculates the hash key using the sha3_256 algorithm. The old implementation, getUserHashKeyV1, is marked as deprecated.

Additionally, a new function, migrateUserHasKeyFromV1, is added to handle the migration of user hash keys from the old implementation to the new one. It retrieves the old hash key, retrieves the stored authentication information associated with it from the local storage, and then stores it with the new hash key. Finally, it removes the old hash key from the local storage.

This commit improves the code structure and prepares for future enhancements in the authentication functionality.

fix #364