### PR TITLE
Refactor TransactionForm to disable "Transaksi Unit Bisnis" checkbox when isDisabled is true

### DIFF
--- a/src/components/pages/cashes/Transaction/Form.tsx
+++ b/src/components/pages/cashes/Transaction/Form.tsx
@@ -249,6 +249,7 @@ export default function TransactionForm({
                             })
                         }>
                         <FormControlLabel
+                            disabled={isDisabled}
                             control={<Checkbox checked={isBuTx} />}
                             label="Transaksi Unit Bisnis"
                         />


### PR DESCRIPTION
This pull request refactors the TransactionForm component to disable the "Transaksi Unit Bisnis" checkbox when the isDisabled prop is set to true. This ensures that the checkbox cannot be interacted with when it is disabled.

fix #321