### PR TITLE
Refactor axios configuration to include API base URL

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -23,6 +23,8 @@ axios.interceptors.request.use(config => {
         config.headers.Authorization = `Bearer ${token}`
     }
 
+    config.baseURL += '/api'
+
     return config
 })
 


### PR DESCRIPTION
This pull request includes a small change to the `src/lib/axios.ts` file. The change modifies the base URL for all requests by appending '/api' to it.

* [`src/lib/axios.ts`](diffhunk://#diff-bfdb8aa3cd43a7af613c63ac93c06d0d320aa32aa153d3fdaf13db4d6a453f68R26-R27): Added a line to append '/api' to the `baseURL` in the request interceptor.