### PR TITLE
Rename wrong field name

### DIFF
--- a/src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx
+++ b/src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx
@@ -134,7 +134,7 @@ export default function ProductMovementDetailArrayFields({
                         <Grid2 xs={2}>
                             <NumericField
                                 disabled={disabled}
-                                name={`${name}.${index}.cost_rp_total`}
+                                name={`${name}.${index}.cost_rp_per_unit`}
                                 numericFormatProps={{
                                     InputProps: {
                                         startAdornment: <RpInputAdornment />,


### PR DESCRIPTION
This pull request includes a small but important change to the `ProductMovementDetailArrayFields` component. The change updates the field name for better clarity and accuracy.

* [`src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx`](diffhunk://#diff-43ea2fd828e9a65e47b11ab74bf4351be711ff1147060383241b10ba30b19699L137-R137): Changed the field name from `cost_rp_total` to `cost_rp_per_unit` to accurately reflect the data being captured.