### PR TITLE
Fix #412 error message display in product purchase forms

### DIFF
--- a/src/components/pages/marts/products/purchases/Form/ProductMovementCostArrayFields.tsx
+++ b/src/components/pages/marts/products/purchases/Form/ProductMovementCostArrayFields.tsx
@@ -39,7 +39,7 @@ export default function ProductMovementCostArrayFields({
                     <AddCircleIcon />
                 </IconButton>
             </Box>
-            <FormHelperText error>{error}</FormHelperText>
+            <FormHelperText error>{JSON.stringify(error)}</FormHelperText>
 
             <Grid2 container columnSpacing={1} alignItems="center">
                 {value?.length > 0 && <HeaderGrid />}

--- a/src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx
+++ b/src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx
@@ -51,7 +51,7 @@ export default function ProductMovementDetailArrayFields({
                     <AddCircleIcon />
                 </IconButton>
             </Box>
-            <FormHelperText error>{error}</FormHelperText>
+            <FormHelperText error>{JSON.stringify(error)}</FormHelperText>
 
             {value && <HeaderGrids />}
 

--- a/src/functions/transform-to-formik-errors.tsx
+++ b/src/functions/transform-to-formik-errors.tsx
@@ -1,0 +1,33 @@
+import type LaravelValidationException from '@/types/LaravelValidationException'
+import type { FormikErrors } from 'formik'
+
+export function transformToFormikErrors<FormValues>(
+    laravelvalidationErrors: LaravelValidationException['errors'],
+): FormikErrors<FormValues> {
+    const output: FormikErrors<FormValues> = {}
+
+    for (const key in laravelvalidationErrors) {
+        const pathParts = key.split('.')
+        let current = output
+
+        pathParts.forEach((part, index) => {
+            const isLastPart = index === pathParts.length - 1
+            const nextPartIsArrayIndex = !isNaN(Number(pathParts[index + 1]))
+
+            if (isLastPart) {
+                // @ts-expect-error - I'm not sure how to fix this
+                current[part] = laravelvalidationErrors[key][0]
+            } else {
+                // @ts-expect-error - I'm not sure how to fix this
+                current[part] =
+                    // @ts-expect-error - I'm not sure how to fix this
+                    current[part] ?? (nextPartIsArrayIndex ? [] : {})
+
+                // @ts-expect-error - I'm not sure how to fix this
+                current = current[part]
+            }
+        })
+    }
+
+    return output
+}


### PR DESCRIPTION
This pull request includes several changes to improve error handling and enhance the user interface in the product purchases form. The most important changes include updating error handling to use a new utility function, transforming Laravel validation errors to Formik errors, and modifying how errors are displayed in the UI.

### Error Handling Improvements:
* [`src/components/pages/marts/products/purchases/FormDialog.tsx`](diffhunk://#diff-aa83c4088190fbe008654b77f6960b55e9094486f5dce15446c986ff13449bf9L6-R8): Replaced the `handle422` function with a new approach that uses `AxiosError` and a custom function `transformToFormikErrors` to handle Laravel validation errors. [[1]](diffhunk://#diff-aa83c4088190fbe008654b77f6960b55e9094486f5dce15446c986ff13449bf9L6-R8) [[2]](diffhunk://#diff-aa83c4088190fbe008654b77f6960b55e9094486f5dce15446c986ff13449bf9L36-R54)
* [`src/functions/transform-to-formik-errors.tsx`](diffhunk://#diff-bc65485234105c6b95b51205ff740a0361b6ba1f28e84dee97d5ca9b8d10ce1aR1-R33): Added a new utility function `transformToFormikErrors` to convert Laravel validation errors into a format compatible with Formik.

### UI Enhancements:
* [`src/components/pages/marts/products/purchases/Form/ProductMovementCostArrayFields.tsx`](diffhunk://#diff-830fb6ed6f915d05ee72f56920fcf7a0dfacdc4b803e9bf8c70b387a69e5d8a2L42-R42): Changed the error display to use `JSON.stringify` for better readability.
* [`src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx`](diffhunk://#diff-43ea2fd828e9a65e47b11ab74bf4351be711ff1147060383241b10ba30b19699L54-R54): Changed the error display to use `JSON.stringify` for better readability.

### Dependency Updates:
* [`src/components/pages/marts/products/purchases/FormDialog.tsx`](diffhunk://#diff-aa83c4088190fbe008654b77f6960b55e9094486f5dce15446c986ff13449bf9L6-R8): Updated imports to include `AxiosError`, `LaravelValidationException`, and `transformToFormikErrors`.