### PR TITLE
Add auto margin on print page

### DIFF
--- a/src/components/PrintHandler/PrintHandler.tsx
+++ b/src/components/PrintHandler/PrintHandler.tsx
@@ -41,6 +41,8 @@ const PrintHandler = memo(function PrintHandler({
 
     const toPrintContentRef = useRef(null)
     const reactToPrintFn = useReactToPrint({
+        pageStyle: '@media print { body { margin: auto; } }',
+        // pageStyle: '@page { size: auto; margin: auto; }',
         contentRef: toPrintContentRef,
         ...props,
     })


### PR DESCRIPTION
margin is disappear because #407 changes

This pull request includes a small change to the `PrintHandler` component to adjust the page styling for print media.

* [`src/components/PrintHandler/PrintHandler.tsx`](diffhunk://#diff-a3a5224ba03ca1647f8afce2417e31cd2aaac1d77b6b23b59fb8b8c897becf73R44-R45): Added a `pageStyle` property to the `useReactToPrint` hook to set the margin for the body element when printing.