### PR TITLE
Remove unnecessary padding in BalanceInSummary and Receipt components

### DIFF
--- a/src/components/pages/marts/products/sales/HistoryDatatableModalAndButton/BalanceInSummary.tsx
+++ b/src/components/pages/marts/products/sales/HistoryDatatableModalAndButton/BalanceInSummary.tsx
@@ -76,7 +76,6 @@ export default function BalanceInSummary() {
                         }}>
                         <Box
                             sx={{
-                                px: 3,
                                 textTransform: 'uppercase !important',
                                 '*': {
                                     color: 'black !important',

--- a/src/components/pages/marts/products/sales/ReceiptPreview/Receipt.tsx
+++ b/src/components/pages/marts/products/sales/ReceiptPreview/Receipt.tsx
@@ -53,7 +53,6 @@ export default function Receipt({
     return (
         <Box
             sx={{
-                px: 3,
                 color: 'black !important',
                 textTransform: 'uppercase',
             }}>


### PR DESCRIPTION
margin is exists again after #416 changes so i deleted margin that determined on each component

This pull request includes minor styling adjustments to two components in the `src/components/pages/marts/products/sales` directory. The changes mainly involve removing padding from specific elements.

Styling adjustments:

* [`src/components/pages/marts/products/sales/HistoryDatatableModalAndButton/BalanceInSummary.tsx`](diffhunk://#diff-d914d4afd4fbc8993671b581b0d9510bf500539e48711cfbe28a0e8772834772L79): Removed padding (`px: 3`) from the `Box` component.
* [`src/components/pages/marts/products/sales/ReceiptPreview/Receipt.tsx`](diffhunk://#diff-3c29f979a6e7a6e2fbf12ffb2b9e4f41766e1f2f125cfe0da4a4a63933a147e1L56): Removed padding (`px: 3`) from the `Box` component.