### PR TITLE
Add user action logs page

### DIFF
--- a/src/components/Layouts/components/menu-list/components/menu-list-data/supermans.ts
+++ b/src/components/Layouts/components/menu-list/components/menu-list-data/supermans.ts
@@ -1,7 +1,7 @@
 // types
 import type { NavItemGroup } from '../@types/nav-item-group'
 // icons
-import { Group, SupervisedUserCircle } from '@mui/icons-material'
+import { Group, Note, SupervisedUserCircle } from '@mui/icons-material'
 // enums
 import Role from '@/enums/Role'
 
@@ -20,6 +20,13 @@ export const supermans: NavItemGroup = {
             label: 'Acting As',
             pathname: '/acting-as',
             icon: Group,
+            forRole: Role.SUPERMAN,
+        },
+        {
+            href: '/_/logs',
+            label: 'Logs',
+            pathname: '/_/logs',
+            icon: Note,
             forRole: Role.SUPERMAN,
         },
     ],

--- a/src/hooks/use-role-checker.ts
+++ b/src/hooks/use-role-checker.ts
@@ -1,0 +1,30 @@
+import Role from '@/enums/Role'
+import useAuth from '@/providers/Auth'
+import { enqueueSnackbar } from 'notistack'
+import { useEffect, useState } from 'react'
+
+export function useRoleChecker(
+    roles: Role[] | Role,
+    onUnauthorized: () => void = defaultOnUnauthorized,
+) {
+    const { user, userHasRole } = useAuth()
+    const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null)
+
+    useEffect(() => {
+        if (user) {
+            const isAuthorizedLocal = userHasRole(roles)
+            setIsAuthorized(isAuthorizedLocal)
+        }
+    }, [user, roles, userHasRole])
+
+    if (isAuthorized === false) onUnauthorized()
+
+    return isAuthorized
+}
+
+function defaultOnUnauthorized() {
+    enqueueSnackbar('Anda tidak memiliki akses untuk halaman ini', {
+        variant: 'error',
+        persist: true,
+    })
+}

--- a/src/pages/_/logs.tsx
+++ b/src/pages/_/logs.tsx
@@ -1,0 +1,68 @@
+import Datatable from '@/components/Datatable'
+import AuthLayout from '@/components/Layouts/AuthLayout'
+import Role from '@/enums/Role'
+import { useRoleChecker } from '@/hooks/use-role-checker'
+import { Typography } from '@mui/material'
+import dayjs from 'dayjs'
+import { MUIDataTableColumn, MUISortOptions } from 'mui-datatables'
+
+export default function Page() {
+    if (!useRoleChecker(Role.SUPERMAN)) return null
+
+    return (
+        <AuthLayout title="Logs">
+            <Datatable
+                tableId="logs-table"
+                apiUrl="_/logs-datatable-data"
+                columns={DATATABLE_COLUMNS}
+                defaultSortOrder={DEFAULT_SORT_ORDER}
+            />
+        </AuthLayout>
+    )
+}
+
+const DEFAULT_SORT_ORDER: MUISortOptions = {
+    name: 'at',
+    direction: 'desc',
+}
+
+const DATATABLE_COLUMNS: MUIDataTableColumn[] = [
+    {
+        name: 'at',
+        label: 'Tanggal',
+        options: {
+            customBodyRender: value =>
+                dayjs(value).format('YYYY-MM-DD HH:mm:ss'),
+        },
+    },
+    {
+        name: 'user.name',
+        label: 'User',
+    },
+    {
+        name: 'action',
+        label: 'Aksi',
+    },
+    {
+        name: 'model_value_changed',
+        label: 'Detail',
+        options: {
+            customBodyRender: (value: object) =>
+                Object.entries(value).map(([key, value], i) => (
+                    <Typography key={i} variant="body2">
+                        <Typography
+                            variant="caption"
+                            color="gray"
+                            component="span">
+                            {key}:&nbsp;
+                        </Typography>
+                        {value as string}
+                    </Typography>
+                )),
+        },
+    },
+    {
+        name: 'model_classname',
+        label: 'Nama Model',
+    },
+]


### PR DESCRIPTION
This pull request introduces a new "Logs" page for users with the "SUPERMAN" role and includes related updates to the navigation and role-checking functionalities.

### New "Logs" Page:
* [`src/pages/_/logs.tsx`](diffhunk://#diff-9bf2178e426b623adaf6b372582715f5428073a2b182d2f3cea4f5253e627613R1-R68): Added a new page that displays a datatable of logs, accessible only to users with the "SUPERMAN" role. The page uses the `useRoleChecker` hook to enforce role-based access.

### Navigation Updates:
* [`src/components/Layouts/components/menu-list/components/menu-list-data/supermans.ts`](diffhunk://#diff-eaf325fbead5f013cf94ad5af9499a9d8c95cfa9c04f73790e84b48c53e4f3f4R25-R31): Added a new menu item for the "Logs" page in the navigation for users with the "SUPERMAN" role.
* [`src/components/Layouts/components/menu-list/components/menu-list-data/supermans.ts`](diffhunk://#diff-eaf325fbead5f013cf94ad5af9499a9d8c95cfa9c04f73790e84b48c53e4f3f4L4-R4): Imported the `Note` icon for the new "Logs" menu item.

### Role-Checking Functionality:
* [`src/hooks/use-role-checker.ts`](diffhunk://#diff-b60e4da2a0b964958eec648ec069c516a2d0694cc99a7867cf75eecc9bedaad2R1-R30): Created a new `useRoleChecker` hook to check if the current user has the required role(s) and handle unauthorized access by displaying an error message.