### PR TITLE
add post request test

### DIFF
--- a/src/components/Layouts/components/menu-list/components/menu-list-data/supermans.ts
+++ b/src/components/Layouts/components/menu-list/components/menu-list-data/supermans.ts
@@ -11,21 +11,24 @@ export const supermans: NavItemGroup = {
         {
             href: '/roles',
             label: 'Peran',
-            pathname: '/roles',
             icon: SupervisedUserCircle,
             forRole: Role.SUPERMAN,
         },
         {
             href: '/acting-as',
             label: 'Acting As',
-            pathname: '/acting-as',
             icon: Group,
             forRole: Role.SUPERMAN,
         },
         {
             href: '/_/logs',
             label: 'Logs',
-            pathname: '/_/logs',
+            icon: Note,
+            forRole: Role.SUPERMAN,
+        },
+        {
+            href: '/_/be-request-test',
+            label: 'BE Request Test',
             icon: Note,
             forRole: Role.SUPERMAN,
         },

--- a/src/pages/_/be-integration-test.tsx
+++ b/src/pages/_/be-integration-test.tsx
@@ -1,0 +1,17 @@
+import AuthLayout from '@/components/Layouts/AuthLayout'
+import Role from '@/enums/Role'
+import { useRoleChecker } from '@/hooks/use-role-checker'
+import axios from '@/lib/axios'
+import { Button } from '@mui/material'
+
+export default function Page() {
+    if (!useRoleChecker(Role.SUPERMAN)) return null
+
+    return (
+        <AuthLayout title="BE Request Test">
+            <Button onClick={() => axios.post('_/fe-integration-test')}>
+                Post to /fe-integration-test
+            </Button>
+        </AuthLayout>
+    )
+}


### PR DESCRIPTION
This pull request includes changes to the navigation menu and the addition of a new page for backend integration testing. The most important changes are adding a new menu item and creating a new page with a button that posts to a specific endpoint.

Changes to the navigation menu:

* [`src/components/Layouts/components/menu-list/components/menu-list-data/supermans.ts`](diffhunk://#diff-eaf325fbead5f013cf94ad5af9499a9d8c95cfa9c04f73790e84b48c53e4f3f4L14-R31): Added a new menu item labeled "BE Request Test" with the appropriate icon and role.

Addition of a new page:

* [`src/pages/_/be-integration-test.tsx`](diffhunk://#diff-886b3ba1d2f8d96ff282873f79bd20d52532626c7a336aa85510e1413e6edc90R1-R17): Created a new page titled "BE Request Test" which includes a button that sends a POST request to the `/fe-integration-test` endpoint.