### PR TITLE
Refactor validation schema to include required field for sales number

### DIFF
--- a/src/components/pages/marts/products/sales/formik-wrapper/statics/validation-scheme.ts
+++ b/src/components/pages/marts/products/sales/formik-wrapper/statics/validation-scheme.ts
@@ -29,7 +29,7 @@ export const VALIDATION_SCHEMA = yup.object().shape({
 
     buyer_user_uuid: yup.string().uuid(),
 
-    // no: yup.number().required('Nomor penjualan tidak boleh kosong'),
+    no: yup.number().required('Nomor penjualan tidak boleh kosong'),
 
     total_payment: yup
         .number()


### PR DESCRIPTION
This pull request includes a minor change to the `VALIDATION_SCHEMA` in the `validation-scheme.ts` file. The change involves uncommenting a validation rule for the `no` field to ensure that it is required.

Validation updates:

* [`src/components/pages/marts/products/sales/formik-wrapper/statics/validation-scheme.ts`](diffhunk://#diff-f29d432461d22879f84d455a75c254322ba66135d1e9ca7eecae5ed138e57100L32-R32): Uncommented the validation rule for the `no` field to make it required.