### PR TITLE
Add window and navigator checks before fetching sales background sync data to fix #435 attempt 4

### DIFF
--- a/src/components/pages/marts/products/sales/bg-sync-panel-dialog-and-button/bg-sync-panel-dialog-and-button.tsx
+++ b/src/components/pages/marts/products/sales/bg-sync-panel-dialog-and-button/bg-sync-panel-dialog-and-button.tsx
@@ -36,13 +36,18 @@ export function BgSyncPanelDialogAndButton() {
         useState<BgSyncQueue<Required<FormValuesType>>[]>()
 
     useEffect(() => {
-        getSalesBgSyncData()
-            .then(data => setBgSyncQueues(data))
-            .catch(msg => {
-                enqueueSnackbar(msg, {
-                    variant: 'warning',
+        if (
+            typeof window !== 'undefined' &&
+            typeof window.navigator !== 'undefined'
+        ) {
+            getSalesBgSyncData()
+                .then(data => setBgSyncQueues(data))
+                .catch(msg => {
+                    enqueueSnackbar(msg, {
+                        variant: 'warning',
+                    })
                 })
-            })
+        }
     }, [])
 
     return (


### PR DESCRIPTION
This pull request includes a small but important change to the `BgSyncPanelDialogAndButton` component in the `bg-sync-panel-dialog-and-button.tsx` file. The change ensures that `getSalesBgSyncData` is only called when the code is running in a browser environment.

* [`src/components/pages/marts/products/sales/bg-sync-panel-dialog-and-button/bg-sync-panel-dialog-and-button.tsx`](diffhunk://#diff-a2621b51b4f6a7f66812a9cdc9888aca17aba134451d8db35ea5eb82a1572cedR39-R50): Added a check to ensure `getSalesBgSyncData` is called only when `window` and `navigator` are defined.