### PR TITLE
Add 'Kode' column and update grand total colspan in sales report table

### DIFF
--- a/src/components/pages/farm-input-product-sales/Report/Table/TableFooter.tsx
+++ b/src/components/pages/farm-input-product-sales/Report/Table/TableFooter.tsx
@@ -47,7 +47,7 @@ function TableFooter({ data }: { data: ProductSaleType[] }) {
                         whiteSpace: 'nowrap',
                     },
                 }}>
-                <TableCell colSpan={10}>GRAND TOTAL</TableCell>
+                <TableCell colSpan={11}>GRAND TOTAL</TableCell>
 
                 <TableCell align="right">
                     {formatNumber(baseCostTotalRp)}

--- a/src/components/pages/farm-input-product-sales/Report/Table/TableHead.tsx
+++ b/src/components/pages/farm-input-product-sales/Report/Table/TableHead.tsx
@@ -16,6 +16,7 @@ function TableHead() {
             <TableRow>
                 <TableCell>#</TableCell>
                 <TableCell>Tanggal</TableCell>
+                <TableCell>Kode</TableCell>
                 <TableCell>Gudang</TableCell>
                 <TableCell>ID</TableCell>
                 <TableCell>Pengguna</TableCell>

--- a/src/components/pages/farm-input-product-sales/Report/Table/TableRow.tsx
+++ b/src/components/pages/farm-input-product-sales/Report/Table/TableRow.tsx
@@ -12,6 +12,7 @@ const LEFT_BORDER_STYLE = {
 
 function TableRow({
     data: {
+        short_uuid,
         product_movement_details,
         product_movement,
         at,
@@ -42,6 +43,7 @@ function TableRow({
         <MuiTableRow>
             <TableCell>{no}</TableCell>
             <TableCell>{toDmy(at)}</TableCell>
+            <TableCell>{short_uuid}</TableCell>
             <TableCell>{ucWords(product_movement.warehouse)}</TableCell>
 
             <TableCell>{buyer_user ? buyer_user.id : '-'}</TableCell>


### PR DESCRIPTION
This pull request includes several changes to the table components in the farm input product sales report. The changes primarily focus on adding a new column for the product code and adjusting the table layout accordingly.

Changes to table layout:

* [`src/components/pages/farm-input-product-sales/Report/Table/TableFooter.tsx`](diffhunk://#diff-fb4db132f1ec3acf23b90fa844b6c8e4d61c6359e8a081290595198ece8ede3bL50-R50): Increased `colSpan` from 10 to 11 in the grand total cell to accommodate the new column.

* [`src/components/pages/farm-input-product-sales/Report/Table/TableHead.tsx`](diffhunk://#diff-3f11b11b81e7e7bceffb6e76bfdd88fa63ac54494baa25e01fff768e8b2027b4R19): Added a new column header for the product code (`Kode`).

Changes to table data:

* [`src/components/pages/farm-input-product-sales/Report/Table/TableRow.tsx`](diffhunk://#diff-eceb2896fbfa2c28dcb989a2a70591e96fc54008b5f875744adfc77ccc0ff0eaR15): Added `short_uuid` to the table row data and included it as a new cell in the table row. [[1]](diffhunk://#diff-eceb2896fbfa2c28dcb989a2a70591e96fc54008b5f875744adfc77ccc0ff0eaR15) [[2]](diffhunk://#diff-eceb2896fbfa2c28dcb989a2a70591e96fc54008b5f875744adfc77ccc0ff0eaR46)