### PR TITLE
Update base cost column name in product data table

### DIFF
--- a/src/pages/marts/products.tsx
+++ b/src/pages/marts/products.tsx
@@ -278,7 +278,7 @@ const columns: MUIDataTableColumn[] = [
         label: 'Satuan',
     },
     {
-        name: 'warehouses.base_cost_rp_per_unit',
+        name: 'warehouses.cost_rp_per_unit',
         label: 'Biaya Dasar',
         options: {
             searchable: false,


### PR DESCRIPTION
Change the column name for base cost in the product data table to improve clarity.

This pull request includes a change to the `src/pages/marts/products.tsx` file to update a column name in the `columns` array.

* [`src/pages/marts/products.tsx`](diffhunk://#diff-9b340d296d1a6c47ecfbdec16302b1bbdb31b1e57db3c6901220e04e447db25aL281-R281): Changed the column name from `warehouses.base_cost_rp_per_unit` to `warehouses.cost_rp_per_unit` in the `columns` array to reflect the updated naming convention.