### PR TITLE
Add refresh button and show last sync products on mart cashier page

### DIFF
--- a/src/components/pages/marts/products/sales/@enums/api-url.ts
+++ b/src/components/pages/marts/products/sales/@enums/api-url.ts
@@ -9,7 +9,7 @@ enum ApiUrl {
     SALES_REPORT = '/marts/products/sales/report',
     BALANCE_IN_SUMMARY = '/marts/products/sales/balance-in-summary',
     DATATABLE = '/marts/products/sales/datatable',
-    PRODUCTS = '/data/marts/products',
+    PRODUCTS = '/marts/products',
     NEW_SALE_NUMBER = '/marts/products/sales/new-sale-number',
     USERS = '/marts/products/sales/users',
     CASHES = '/marts/products/sales/cashes',

--- a/src/components/pages/marts/products/sales/product-picker/components/result-nav.tsx
+++ b/src/components/pages/marts/products/sales/product-picker/components/result-nav.tsx
@@ -1,48 +1,91 @@
-import { Box, IconButton, Typography } from '@mui/material'
+import { Box, Fade, IconButton, Typography } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
-import { memo } from 'react'
+import { memo, useEffect, useState } from 'react'
+import { Refresh } from '@mui/icons-material'
+import dayjs, { extend } from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+
+extend(relativeTime)
 
 function ResultNav({
     itemTotal,
     currentSearchPageNo,
     productPerPage,
+    fetchedAt,
     onNext,
     onPrev,
+    onRefresh,
 }: {
     itemTotal: number
     currentSearchPageNo: number
     productPerPage: number
+    fetchedAt?: string
     onNext: () => void
     onPrev: () => void
+    onRefresh: () => void
 }) {
+    const [cooldown, setCooldown] = useState(true)
     const maxPage = Math.ceil(itemTotal / 8)
+
+    useEffect(() => {
+        if (cooldown) {
+            const timeout = setTimeout(
+                () => {
+                    setCooldown(false)
+                },
+                1000 * 5 * 60, // 5 minutes
+            )
+
+            return () => clearTimeout(timeout)
+        }
+    }, [cooldown])
 
     return (
         <Box
             display="flex"
             alignItems="center"
-            gap={1}
+            justifyContent="space-between"
             sx={{
                 color: 'GrayText',
             }}>
-            <IconButton size="small" onClick={onPrev}>
-                <ArrowBackIcon color="disabled" />
-            </IconButton>
+            <Box display="flex" alignItems="center" gap={1}>
+                <IconButton size="small" onClick={onPrev}>
+                    <ArrowBackIcon color="disabled" />
+                </IconButton>
 
-            <Typography variant="overline">
-                {currentSearchPageNo} / {maxPage}
-            </Typography>
+                <Typography variant="overline">
+                    {Math.min(currentSearchPageNo, maxPage)} / {maxPage}
+                </Typography>
 
-            <IconButton size="small" onClick={onNext}>
-                <ArrowForwardIcon color="disabled" />
-            </IconButton>
+                <IconButton size="small" onClick={onNext}>
+                    <ArrowForwardIcon color="disabled" />
+                </IconButton>
 
-            <Typography variant="caption">
-                Menampilkan{' '}
-                {productPerPage > itemTotal ? itemTotal : productPerPage} dari{' '}
-                {itemTotal} barang
-            </Typography>
+                <Typography variant="caption">
+                    Menampilkan {Math.min(itemTotal, productPerPage)} dari{' '}
+                    {itemTotal} barang
+                </Typography>
+            </Box>
+
+            <Box display="flex" gap={1} alignItems="center">
+                {fetchedAt && (
+                    <Typography variant="caption">
+                        terakhir disinkronkan: {dayjs(fetchedAt).fromNow()}
+                    </Typography>
+                )}
+
+                <Fade in={!cooldown} unmountOnExit>
+                    <IconButton
+                        size="small"
+                        onClick={() => {
+                            onRefresh()
+                            setCooldown(true)
+                        }}>
+                        <Refresh color="disabled" />
+                    </IconButton>
+                </Fade>
+            </Box>
         </Box>
     )
 }


### PR DESCRIPTION
This pull request introduces several enhancements and fixes in the product sales module, focusing on improving the user interface and data handling. The most important changes include updating the API URL, adding new functionalities to the `ResultNav` component, and modifying the `ProductPicker` component to handle data more efficiently.

### API URL Update:
* Updated the `PRODUCTS` endpoint in the `ApiUrl` enum to use the correct path. (`src/components/pages/marts/products/sales/@enums/api-url.ts`)

### `ResultNav` Component Enhancements:
* Added new imports and functionalities, including `Fade`, `useEffect`, `useState`, and `dayjs` for better UI interaction and data display. (`src/components/pages/marts/products/sales/product-picker/components/result-nav.tsx`)
* Introduced a cooldown mechanism for the refresh button to prevent frequent data fetching. (`src/components/pages/marts/products/sales/product-picker/components/result-nav.tsx`)
* Displayed the last synchronization time using `dayjs` to enhance user awareness of data freshness. (`src/components/pages/marts/products/sales/product-picker/components/result-nav.tsx`)

### `ProductPicker` Component Modifications:
* Updated the `ApiResponseType` to include `fetched_at` and refactored the data structure for better type safety. (`src/components/pages/marts/products/sales/product-picker/index.tsx`)
* Implemented `mutate` from `useSWR` to allow refreshing data on demand. (`src/components/pages/marts/products/sales/product-picker/index.tsx`) [[1]](diffhunk://#diff-87b57fa7821d9ebe2a504c5c127a49124b663a43dec45b49718e67d4ef6deb43L24-R42) [[2]](diffhunk://#diff-87b57fa7821d9ebe2a504c5c127a49124b663a43dec45b49718e67d4ef6deb43R136-R139)
* Refactored product filtering logic to handle potential undefined data gracefully. (`src/components/pages/marts/products/sales/product-picker/index.tsx`) [[1]](diffhunk://#diff-87b57fa7821d9ebe2a504c5c127a49124b663a43dec45b49718e67d4ef6deb43L59-R73) [[2]](diffhunk://#diff-87b57fa7821d9ebe2a504c5c127a49124b663a43dec45b49718e67d4ef6deb43L98-R109) [[3]](diffhunk://#diff-87b57fa7821d9ebe2a504c5c127a49124b663a43dec45b49718e67d4ef6deb43L118-R125)