### PR TITLE
Update SWR data structure in ProductMovementDetailArrayFields to include fetched_at and is_in_opname properties

### DIFF
--- a/src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx
+++ b/src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx
@@ -35,7 +35,12 @@ export default function ProductMovementDetailArrayFields({
 }) {
     const { value, error } = getFieldMeta<FormValues['details']>(name)
 
-    const { data: products, isLoading } = useSWR<Product[]>(
+    const { data: products, isLoading } = useSWR<{
+        fetched_at: string
+        data: (Product & {
+            is_in_opname: boolean
+        })[]
+    }>(
         // TODO: change this to the Enum
         'marts/products',
     )
@@ -85,7 +90,7 @@ export default function ProductMovementDetailArrayFields({
                                         isOptionEqualToValue={(option, value) =>
                                             option.id === value.id
                                         }
-                                        options={products ?? []}
+                                        options={products?.data ?? []}
                                         disabled={disabled}
                                         getOptionLabel={({ id, code, name }) =>
                                             `${code ?? id} - ${name}`


### PR DESCRIPTION
caused by: #459 

This pull request includes updates to the `ProductMovementDetailArrayFields` component in the `ProductMovementDetailArrayFields.tsx` file to enhance the structure of the `products` data fetched and used within the component.

Key changes:

* Modified the data structure returned by the `useSWR` hook to include additional metadata and nested product details. (`src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx`)
* Updated the `options` prop in the `Autocomplete` component to use the nested `data` array from the `products` object. (`src/components/pages/marts/products/purchases/Form/ProductMovementDetailArrayFields.tsx`)