### PR TITLE
Enhance `ProductCard` component to highlight search text and include `barcode_reg_id`

### DIFF
--- a/src/components/pages/marts/products/sales/product-picker/components/product-card.tsx
+++ b/src/components/pages/marts/products/sales/product-picker/components/product-card.tsx
@@ -27,6 +27,7 @@ function ProductCard({
         id,
         code,
         name,
+        barcode_reg_id,
         description,
         category_name,
         unit,
@@ -34,11 +35,13 @@ function ProductCard({
         deleted_at,
         is_in_opname,
     },
+    searchText,
     onClick,
 }: {
     data: Product & {
         is_in_opname: boolean
     }
+    searchText: string
     onClick: CardActionAreaProps['onClick']
 }) {
     const { status } = useFormikContext()
@@ -107,12 +110,30 @@ function ProductCard({
                             component="div"
                             variant="caption"
                             color="text.disabled">
-                            #{id}
-                            {code ? ` / ${code}` : ''}
+                            #{getHighlightedText(id.toString(), searchText)}
+                            {code ? (
+                                <>
+                                    {' / '}
+                                    {getHighlightedText(code, searchText)}
+                                </>
+                            ) : (
+                                ''
+                            )}
+                            {barcode_reg_id ? (
+                                <>
+                                    {' / '}
+                                    {getHighlightedText(
+                                        barcode_reg_id,
+                                        searchText,
+                                    )}
+                                </>
+                            ) : (
+                                ''
+                            )}
                         </Typography>
 
                         <Typography component="div">
-                            {name}
+                            {getHighlightedText(name, searchText)}
 
                             <Typography
                                 mt={-1}
@@ -154,3 +175,24 @@ function ProductCard({
 }
 
 export default memo(ProductCard)
+
+function getHighlightedText(text: string, highlight: string) {
+    const parts = text.split(new RegExp(`(${highlight})`, 'gi'))
+
+    return (
+        <>
+            {parts.map((part, i) => (
+                <Box
+                    component="span"
+                    key={i}
+                    color={
+                        part.toLowerCase() === highlight.toLowerCase()
+                            ? 'warning.main'
+                            : undefined
+                    }>
+                    {part}
+                </Box>
+            ))}
+        </>
+    )
+}

--- a/src/components/pages/marts/products/sales/product-picker/index.tsx
+++ b/src/components/pages/marts/products/sales/product-picker/index.tsx
@@ -176,6 +176,7 @@ function ProductPicker({
                             spacing={2}>
                             {filteredProducts.map(product => (
                                 <ProductCard
+                                    searchText={query}
                                     key={product.id}
                                     data={product}
                                     onClick={() => {
@@ -198,6 +199,7 @@ function ProductPicker({
                             }}>
                             {filteredProducts.map(product => (
                                 <ProductCard
+                                    searchText={query}
                                     key={product.id}
                                     data={product}
                                     onClick={() => {


### PR DESCRIPTION
This pull request enhances the `ProductCard` component by adding a search highlighting feature. The changes include passing a search text to the component and highlighting matching text in the product details.

### Enhancements to `ProductCard` component:

* Added `searchText` prop to `ProductCard` to pass the search query. (`src/components/pages/marts/products/sales/product-picker/components/product-card.tsx`)
* Implemented `getHighlightedText` function to highlight matching search text in product details. (`src/components/pages/marts/products/sales/product-picker/components/product-card.tsx`)
* Updated product details rendering to use `getHighlightedText` for `id`, `code`, `barcode_reg_id`, and `name`. (`src/components/pages/marts/products/sales/product-picker/components/product-card.tsx`)

### Updates to `ProductPicker` component:

* Passed `searchText` prop to `ProductCard` instances to enable text highlighting. (`src/components/pages/marts/products/sales/product-picker/index.tsx`) [[1]](diffhunk://#diff-87b57fa7821d9ebe2a504c5c127a49124b663a43dec45b49718e67d4ef6deb43R179) [[2]](diffhunk://#diff-87b57fa7821d9ebe2a504c5c127a49124b663a43dec45b49718e67d4ef6deb43R202)