### PR TITLE
Remove unused sale number handling when offline

### DIFF
--- a/src/components/pages/marts/products/sales/@enums/api-url.ts
+++ b/src/components/pages/marts/products/sales/@enums/api-url.ts
@@ -10,7 +10,14 @@ enum ApiUrl {
     BALANCE_IN_SUMMARY = '/marts/products/sales/balance-in-summary',
     DATATABLE = '/marts/products/sales/datatable',
     PRODUCTS = '/marts/products',
-    NEW_SALE_NUMBER = '/marts/products/sales/new-sale-number',
+
+    /**
+     * Disable this endpoint because it's not used in the project
+     *
+     * @see https://github.com/sensasi-apps/ekbs-nextjs/issues/434
+     */
+    // NEW_SALE_NUMBER = '/marts/products/sales/new-sale-number',
+
     USERS = '/marts/products/sales/users',
     CASHES = '/marts/products/sales/cashes',
 }

--- a/src/components/pages/marts/products/sales/@shared-subcomponents/default-item-desc.tsx
+++ b/src/components/pages/marts/products/sales/@shared-subcomponents/default-item-desc.tsx
@@ -6,7 +6,7 @@ function DefaultItemDesc({
     value,
 }: {
     desc: string
-    value: string | undefined
+    value: number | string
 }) {
     return (
         <Box display="flex" gap={0.75}>
@@ -22,7 +22,7 @@ function DefaultItemDesc({
             </Typography>
 
             <Typography variant="caption" component="div" fontWeight="bold">
-                {value ?? ''}
+                {value}
             </Typography>
         </Box>
     )

--- a/src/components/pages/marts/products/sales/@shared-subcomponents/receipt.tsx
+++ b/src/components/pages/marts/products/sales/@shared-subcomponents/receipt.tsx
@@ -29,7 +29,7 @@ export default function Receipt({
 }: {
     data: {
         at: ProductMovement['at']
-        saleNo: ProductMovementSale['no']
+        saleNo?: ProductMovementSale['no']
         details: Omit<ProductMovementDetail, 'id'>[]
         costs: ProductMovement['costs']
         transactionCashName: CashType['name']
@@ -73,10 +73,7 @@ export default function Receipt({
                 <Box>
                     <DefaultItemDesc desc="Pada" value={at} />
 
-                    <DefaultItemDesc
-                        desc="NO. Nota"
-                        value={saleNo.toString()}
-                    />
+                    <DefaultItemDesc desc="NO. Nota" value={saleNo ?? '-'} />
 
                     <DefaultItemDesc desc="Kasir" value={servedByUserName} />
 

--- a/src/components/pages/marts/products/sales/bg-sync-panel-dialog-and-button/bg-sync-panel-dialog-and-button.tsx
+++ b/src/components/pages/marts/products/sales/bg-sync-panel-dialog-and-button/bg-sync-panel-dialog-and-button.tsx
@@ -98,7 +98,7 @@ export function BgSyncPanelDialogAndButton() {
                     <Table size="small">
                         <TableHead>
                             <TableRow>
-                                <TableCell>NO</TableCell>
+                                <TableCell>#</TableCell>
                                 <TableCell>Barang</TableCell>
                                 <TableCell>Total</TableCell>
                                 <TableCell>Waktu kirim data</TableCell>
@@ -122,7 +122,7 @@ export function BgSyncPanelDialogAndButton() {
 
                             {bgSyncQueues?.map((queue, i) => (
                                 <TableRow key={i}>
-                                    <TableCell>{queue.body.no}</TableCell>
+                                    <TableCell>{i + 1}</TableCell>
 
                                     <TableCell>
                                         <Values data={queue.body} />
@@ -155,7 +155,6 @@ export function BgSyncPanelDialogAndButton() {
                                             <Receipt
                                                 data={{
                                                     at: queue.body.at,
-                                                    saleNo: queue.body.no,
                                                     servedByUserName:
                                                         queue.body.buyer_user
                                                             ?.name ?? '-',

--- a/src/components/pages/marts/products/sales/formik-wrapper/@types/form-values-type.ts
+++ b/src/components/pages/marts/products/sales/formik-wrapper/@types/form-values-type.ts
@@ -11,7 +11,6 @@ export interface FormValuesType {
     cashable_name?: CashType['name']
     buyer_user_uuid?: ProductMovementSale['buyer_user_uuid']
     buyer_user?: ProductMovementSale['buyer_user']
-    no?: ProductMovementSale['no']
     total_payment?: ProductMovementSale['total_payment']
     details: {
         product: ProductMovementDetail['product']

--- a/src/components/pages/marts/products/sales/formik-wrapper/@types/formik-status-type.ts
+++ b/src/components/pages/marts/products/sales/formik-wrapper/@types/formik-status-type.ts
@@ -3,7 +3,5 @@ import { FormValuesType } from './form-values-type'
 export interface FormikStatusType {
     isDisabled: boolean
     isFormOpen: boolean
-    submittedData?: Required<FormValuesType> & {
-        no?: FormValuesType['no']
-    }
+    submittedData?: Required<FormValuesType>
 }

--- a/src/components/pages/marts/products/sales/formik-wrapper/components/create-sale-form-wrapper/components/create-sale-form/index.tsx
+++ b/src/components/pages/marts/products/sales/formik-wrapper/components/create-sale-form-wrapper/components/create-sale-form/index.tsx
@@ -2,10 +2,9 @@
 import type { FormikStatusType, FormValuesType } from '../../../..'
 // vendors
 import { Field, FieldProps, useFormikContext } from 'formik'
-import { memo, useEffect } from 'react'
+import { memo } from 'react'
 import { Box, Divider, Typography } from '@mui/material'
 import Grid2 from '@mui/material/Unstable_Grid2'
-import useSWR from 'swr'
 // subcomponents
 import { NumericField } from '@/components/FormikForm'
 import BuyerUserUuidFieldComponent from './components/buyer-user-uuid-field-component'
@@ -14,41 +13,20 @@ import CostsFieldComponent from './components/costs-field-component'
 import DefaultItemDesc from '../../../../../@shared-subcomponents/default-item-desc'
 import DetailsFieldComponent from './components/details-field-component'
 // utils
-import ApiUrl from '../../../../../@enums/api-url'
 import formatNumber from '@/utils/formatNumber'
 import useAuth from '@/providers/Auth'
 
 function CreateSaleForm() {
     const { user } = useAuth()
-    const { setFieldValue, status, isSubmitting } =
-        useFormikContext<FormValuesType>()
-
-    const { data: newNumber } = useSWR<number>(ApiUrl.NEW_SALE_NUMBER, {
-        keepPreviousData: true,
-    })
-
-    useEffect(() => {
-        if (!newNumber) return
-
-        setFieldValue('no', newNumber)
-    }, [newNumber, setFieldValue])
+    const { status, isSubmitting } = useFormikContext<FormValuesType>()
 
     const typedStatus = status as FormikStatusType
 
     return (
         <>
             <DefaultItemDesc
-                desc="TGL"
-                value={typedStatus?.submittedData?.at}
-            />
-
-            <DefaultItemDesc
-                desc="NO. Nota"
-                value={
-                    typedStatus?.submittedData?.no.toString() ??
-                    newNumber?.toString() ??
-                    ''
-                }
+                desc="Pada"
+                value={typedStatus?.submittedData?.at ?? '-'}
             />
 
             <DefaultItemDesc desc="Kasir" value={user?.name ?? ''} />

--- a/src/components/pages/marts/products/sales/formik-wrapper/components/create-sale-form-wrapper/create-sale-form-wrapper.tsx
+++ b/src/components/pages/marts/products/sales/formik-wrapper/components/create-sale-form-wrapper/create-sale-form-wrapper.tsx
@@ -3,7 +3,6 @@ import type {
     FormValuesType,
 } from '@/components/pages/marts/products/sales/formik-wrapper'
 // vendors
-import { useEffect } from 'react'
 import { Box, Collapse, Fade, IconButton, Paper, Tooltip } from '@mui/material'
 import { LoadingButton } from '@mui/lab'
 import { useFormikContext } from 'formik'
@@ -12,7 +11,6 @@ import {
     AddBox as AddBoxIcon,
     Close as CloseIcon,
 } from '@mui/icons-material'
-import useSWR from 'swr'
 // global components
 import PrintHandler from '@/components/PrintHandler'
 // subcomponents
@@ -20,14 +18,12 @@ import CreateSaleForm from './components/create-sale-form'
 import Receipt from '../../../@shared-subcomponents/receipt'
 // utils
 import useAuth from '@/providers/Auth'
-import ApiUrl from '../../../@enums/api-url'
 
 export function CreateSaleFormWrapper() {
     const {
         handleSubmit,
         handleReset,
         setStatus,
-        setFieldValue,
         isSubmitting,
         dirty,
         status,
@@ -35,17 +31,6 @@ export function CreateSaleFormWrapper() {
     } = useFormikContext<FormValuesType>()
     const { user } = useAuth()
     const { isDisabled, isFormOpen, submittedData } = status as FormikStatusType
-    const { mutate } = useSWR(ApiUrl.NEW_SALE_NUMBER, {
-        keepPreviousData: true,
-    })
-
-    useEffect(() => {
-        if (isFormOpen) {
-            mutate().then(newNumber => {
-                setFieldValue('no', newNumber)
-            })
-        }
-    }, [isFormOpen, mutate, setFieldValue])
 
     const isSubmitted = Boolean(submittedData)
 
@@ -86,7 +71,6 @@ export function CreateSaleFormWrapper() {
                             <Receipt
                                 data={{
                                     at: submittedData.at,
-                                    saleNo: submittedData.no,
                                     servedByUserName: user?.name ?? '-',
                                     saleBuyerUser: submittedData.buyer_user,
                                     transactionCashName:


### PR DESCRIPTION
Eliminate the handling of the sale number request when offline by removing the associated API endpoint and adjusting related components to prevent displaying the sale number before it is recorded in the database. This change addresses issue #434.