### PR TITLE
Remove file extension from downloaded file name in payment form

### DIFF
--- a/src/components/PalmBunchesReaPayment/Form.tsx
+++ b/src/components/PalmBunchesReaPayment/Form.tsx
@@ -181,7 +181,7 @@ export default function PalmBuncesReaPaymentForm({
                                     .then(res =>
                                         fileDownload(
                                             res.data,
-                                            `${file?.name || excel_file?.alias}.${excel_file?.extension}`,
+                                            `${file?.name || excel_file?.alias}`,
                                         ),
                                     )
                             }


### PR DESCRIPTION
Eliminate the file extension from the name of downloaded files in the payment form to simplify the naming convention.