### PR TITLE
Fix API URL for product opname creation

### DIFF
--- a/src/enums/ApiUrl/Mart/Product/Opname.ts
+++ b/src/enums/ApiUrl/Mart/Product/Opname.ts
@@ -5,7 +5,7 @@ enum OpnameApiUrl {
     PRODUCTS_DATA = ApiUrl.PRODUCTS,
     DATATABLE = 'marts/products/opnames/datatable',
 
-    CREATE = 'marts/products/opnames/',
+    CREATE = 'marts/products/opnames',
     ADD_PRODUCTS = 'marts/products/opnames/$/add-products',
     GET_DETAIL = 'marts/products/opnames/$',
     REMOVE_PRODUCT = 'marts/products/opnames/$pmdId/remove-product',


### PR DESCRIPTION
Remove the trailing slash from the API URL for product opname creation to ensure correct endpoint access.