### PR TITLE
Refactor LoanDatatable to conditionally adjust columns based on user mode

### DIFF
--- a/src/components/pages/user-loans/Datatable.tsx
+++ b/src/components/pages/user-loans/Datatable.tsx
@@ -42,17 +42,15 @@ export default function LoanDatatable({
 
     const TITLE = mode === 'manager' ? 'Daftar Pinjaman' : 'Riwayat'
 
-    const columns = [...DATATABLE_COLUMNS]
-
-    if (mode === 'applier') {
-        columns.splice(2, 1)
-    }
-
     return (
         <Datatable
             apiUrl={API_URL}
             apiUrlParams={apiUrlParams}
-            columns={columns}
+            columns={
+                mode === 'applier'
+                    ? DATATABLE_COLUMNS.splice(3, 1)
+                    : DATATABLE_COLUMNS
+            }
             defaultSortOrder={DEFAULT_SORT_ORDER}
             onRowClick={handleRowClick}
             tableId="loans-table"


### PR DESCRIPTION
Adjust the LoanDatatable component to conditionally modify the columns displayed based on the user mode, addressing the issue of accessing array offsets on null. This change ensures that the correct columns are rendered for both 'manager' and 'applier' modes.

Fixes #528