### PR TITLE
Update react-to-print dependency for stability improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "react-barcode-reader": "^0.0.2",
                 "react-dom": "^18.3.1",
                 "react-number-format": "^5.4.2",
-                "react-to-print": "github:sensasi-delight/react-to-print#patch",
+                "react-to-print": "github:sensasi-delight/react-to-print#sensasi-delight",
                 "react-use-is-online": "^1.3.0",
                 "react-virtualized": "^9.22.5",
                 "recharts": "^2.14.1",
@@ -12807,8 +12807,8 @@
             }
         },
         "node_modules/react-to-print": {
-            "version": "3.0.2",
-            "resolved": "git+ssh://git@github.com/sensasi-delight/react-to-print.git#e0f746ce0f83406133fc4934e125f63730ca99ec",
+            "version": "3.0.3-sensasi-delight.1",
+            "resolved": "git+ssh://git@github.com/sensasi-delight/react-to-print.git#3582ae444ba468782e5f4ad7d53e16bd6b855de1",
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ~19"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "react-barcode-reader": "^0.0.2",
         "react-dom": "^18.3.1",
         "react-number-format": "^5.4.2",
-        "react-to-print": "github:sensasi-delight/react-to-print#patch",
+        "react-to-print": "github:sensasi-delight/react-to-print#sensasi-delight",
         "react-use-is-online": "^1.3.0",
         "react-virtualized": "^9.22.5",
         "recharts": "^2.14.1",


### PR DESCRIPTION
Switch to a specific branch of the react-to-print dependency to enhance stability.