### PR TITLE
Use column name directly in DataTable parameters

### DIFF
--- a/src/components/Datatable/utils/formatToDatatableParams.ts
+++ b/src/components/Datatable/utils/formatToDatatableParams.ts
@@ -36,9 +36,9 @@ export default function formatToDatatableParams(
 function formatColumns(
     columns: MUIDataTableColumnState[],
 ): DataTableRequest['columns'] {
-    return columns.map(({ name, label, searchable, sort }) => ({
+    return columns.map(({ name, searchable, sort }) => ({
         data: name,
-        name: label ?? name,
+        name: name,
         searchable: searchable ?? true,
         orderable: sort ?? true,
     }))


### PR DESCRIPTION
Refactor the DataTable parameter formatting to use the column name directly instead of the label, addressing prioritization issues with the Yajra library.