### PR TITLE
Modernizes URL patterns and Next.js link integration

### DIFF
--- a/src/app/(auth)/clm/members/[user_uuid]/_components/tabs.land-card.tsx
+++ b/src/app/(auth)/clm/members/[user_uuid]/_components/tabs.land-card.tsx
@@ -45,7 +45,7 @@ export default function LandCard({ land }: { land: Land }) {
     return (
         <Card>
             <CardActionArea
-                component={Link}
+                LinkComponent={Link}
                 href={`${user_uuid}/lands/${land.uuid}`}>
                 <CardContent sx={{ p: 3 }}>
                     <FlexBox mb={1} justifyContent="space-between">

--- a/src/app/(auth)/clm/members/[user_uuid]/lands/[land_uuid]/land-requisite-card.tsx
+++ b/src/app/(auth)/clm/members/[user_uuid]/lands/[land_uuid]/land-requisite-card.tsx
@@ -33,7 +33,7 @@ export default function RequisiteLandCard({
             }}>
             <CardActionArea
                 href={`${requisiteLand.land_uuid}/requisite/${requisiteLand.requisite_id}`}
-                component={Link}>
+                LinkComponent={Link}>
                 <CardContent
                     sx={{
                         display: 'flex',

--- a/src/app/(auth)/clm/members/page.tsx
+++ b/src/app/(auth)/clm/members/page.tsx
@@ -68,7 +68,7 @@ export default function Members() {
                         const member = getRowDataRef.current?.(dataIndex)
 
                         if (member) {
-                            push('/clm/members/' + member.user_uuid)
+                            push(`/clm/members/${member.user_uuid}`)
                         }
                     }
                 }}

--- a/src/app/(auth)/executive/profit-loss/_components/tab-chips.tsx
+++ b/src/app/(auth)/executive/profit-loss/_components/tab-chips.tsx
@@ -38,11 +38,11 @@ export function TabChips({
     )
 
     function handleActiveTabChange(value: string) {
-        replace('?' + createQueryString('activeTab', value))
+        replace(`?${createQueryString('activeTab', value)}`)
     }
 
     function handleYearChange(value: string) {
-        replace('?' + createQueryString('year', value))
+        replace(`?${createQueryString('year', value)}`)
     }
 
     return (

--- a/src/app/(auth)/farm-inputs/my-purchases/page.tsx
+++ b/src/app/(auth)/farm-inputs/my-purchases/page.tsx
@@ -20,15 +20,13 @@ import PageTitle from '@/components/page-title'
 import ProductSaleReceipt from '@/components/pages/farm-input-product-sales/Receipt'
 //
 import type ProductSaleORM from '@/modules/farm-inputs/types/orms/product-sale'
-import {
-    type ApiResponseType,
-    LineChartCard,
-} from '@/app/(auth)/me/participation/page'
+import { type ApiResponseType } from '@/app/(auth)/me/participation/page'
 // utils
 import toDmy from '@/utils/to-dmy'
 import nowrapMuiDatatableCellPropsFn from '@/utils/nowrap-mui-datatable-cell-props-fn'
 import formatNumber from '@/utils/format-number'
 import FlexBox from '@/components/flex-box'
+import LineChartCard from '@/components/line-chart-card'
 
 let getRowData: GetRowDataType<ProductSaleORM>
 

--- a/src/app/(auth)/farm-inputs/product-sales/reports/page.tsx
+++ b/src/app/(auth)/farm-inputs/product-sales/reports/page.tsx
@@ -31,7 +31,7 @@ export default function FarmInputProductSalesReport() {
     } = useSWR<ProductSaleORM[]>(
         from_date && till_date
             ? [
-                  apiUrl,
+                  'farm-inputs/product-sales/report',
                   {
                       from_date: from_date,
                       till_date: till_date,
@@ -86,5 +86,3 @@ export default function FarmInputProductSalesReport() {
         </>
     )
 }
-
-export const apiUrl = 'farm-inputs/product-sales/report'

--- a/src/app/(auth)/finances/receivables/report/page.tsx
+++ b/src/app/(auth)/finances/receivables/report/page.tsx
@@ -254,12 +254,10 @@ function MonthPicker() {
                 onAccept={date => {
                     if (!date) return
 
-                    replace(
-                        '?year=' +
-                            date.format('YYYY') +
-                            '&month=' +
-                            date.format('MM'),
-                    )
+                    const year = date.format('YYYY')
+                    const month = date.format('MM')
+
+                    replace(`?year=${year}&month=${month}`)
                 }}
                 views={['year', 'month']}
                 sx={{

--- a/src/app/(auth)/heavy-equipment-rents/_parts/her-datatable.tsx
+++ b/src/app/(auth)/heavy-equipment-rents/_parts/her-datatable.tsx
@@ -76,9 +76,7 @@ export default function HeavyEquipmentRentsDatatable({
                     slotProps={{
                         field: {
                             clearable: true,
-                            onClear: () => {
-                                replace('')
-                            },
+                            onClear: () => replace('?'),
                         },
                         textField: {
                             margin: 'none',

--- a/src/app/(auth)/inventories/items/[uuid]/page.tsx
+++ b/src/app/(auth)/inventories/items/[uuid]/page.tsx
@@ -9,7 +9,7 @@ import type {
 } from '@/components/Datatable'
 // vendors
 import type { AxiosResponse } from 'axios'
-import { useParams, useRouter } from 'next/navigation'
+import { notFound, useParams } from 'next/navigation'
 import axios from '@/lib/axios'
 import useSWR from 'swr'
 // materials
@@ -35,7 +35,6 @@ let getPicRowData: GetRowDataType<InventoryItem['latest_pic']>
 let getCheckupRowData: GetRowDataType<InventoryItem['latest_checkup']>
 
 export default function InventoryItemDetail() {
-    const { replace } = useRouter()
     const param = useParams()
     const uuid = param?.uuid as string
 
@@ -48,7 +47,7 @@ export default function InventoryItemDetail() {
             })),
         {
             onError: err => {
-                if (err.response?.status === 404) replace('/404')
+                if (err.response?.status === 404) notFound()
             },
         },
     )

--- a/src/app/(auth)/marts/products/opnames/page.tsx
+++ b/src/app/(auth)/marts/products/opnames/page.tsx
@@ -60,7 +60,7 @@ export default function Opnames() {
                         const data = getRowData(dataIndex)
                         if (!data) return
 
-                        push('opnames/' + data.uuid)
+                        push(`/marts/products/opnames/${data.uuid}`)
                     }
                 }}
                 tableId="opnames-table"
@@ -70,7 +70,7 @@ export default function Opnames() {
 
             <FormDialog
                 formValues={formValues}
-                onSubmitted={uuid => push('opnames/' + uuid)}
+                onSubmitted={uuid => push(`/marts/products/opnames/${uuid}`)}
                 onClose={handleClose}
             />
 

--- a/src/app/(auth)/me/participation/page.tsx
+++ b/src/app/(auth)/me/participation/page.tsx
@@ -18,16 +18,14 @@ import Forest from '@mui/icons-material/Forest'
 import ShoppingCart from '@mui/icons-material/ShoppingCart'
 import Warehouse from '@mui/icons-material/Warehouse'
 // components
-import LineChart from '@/components/Chart/Line'
 import PageTitle from '@/components/page-title'
-import StatCard from '@/components/StatCard'
 // utils
 import Role from '@/enums/role'
-import BigNumberCard, {
-    type BigNumberCardProps,
-} from '@/components/big-number-card'
+import BigNumberCard from '@/components/big-number-card'
 // hooks
 import useIsAuthHasRole from '@/hooks/use-is-auth-has-role'
+import type SectionData from '@/types/section-data'
+import LineChartCard from '@/components/line-chart-card'
 
 export interface ApiResponseType {
     palmBunches: SectionData
@@ -94,15 +92,6 @@ export default function Page() {
             />
         </>
     )
-}
-
-interface SectionData {
-    bigNumber1: BigNumberCardProps
-    bigNumber2: BigNumberCardProps
-    lineChart: {
-        title: string
-        data: { label: string; value: number }[]
-    }
 }
 
 function SectionHeader({
@@ -214,32 +203,5 @@ function Section({
                 />
             )}
         </Box>
-    )
-}
-
-export function LineChartCard({
-    title,
-    data,
-    collapsible,
-    ...rest
-}: SectionData['lineChart'] & { suffix?: string; collapsible?: boolean }) {
-    const isHigherThanPrevious =
-        data[data.length - 1].value > data[data.length - 2].value
-
-    return (
-        <StatCard
-            title={title}
-            collapsible={collapsible}
-            color={isHigherThanPrevious ? 'success' : 'error'}>
-            <LineChart
-                {...rest}
-                data={data}
-                lineProps={{
-                    stroke: isHigherThanPrevious
-                        ? 'var(--mui-palette-success-main)'
-                        : 'var(--mui-palette-error-main)',
-                }}
-            />
-        </StatCard>
     )
 }

--- a/src/app/(auth)/repair-shop/sales/page.tsx
+++ b/src/app/(auth)/repair-shop/sales/page.tsx
@@ -44,7 +44,9 @@ export default function Page() {
                     if (event.detail === 2) {
                         const data = getRowDataRef.current?.(dataIndex)
 
-                        push(`sales/${data?.uuid}`)
+                        if (!data) return
+
+                        push(`/repair-shop/sales/${data.uuid}`)
                     }
                 }}
                 title="Riwayat"

--- a/src/app/(auth)/repair-shop/spare-part-purchases/page.tsx
+++ b/src/app/(auth)/repair-shop/spare-part-purchases/page.tsx
@@ -51,7 +51,9 @@ export default function Page() {
                         const data = getRowDataRef.current?.(dataIndex)
 
                         if (data) {
-                            push(`spare-part-purchases/${data.uuid}`)
+                            push(
+                                `/repair-shop/spare-part-purchases/${data.uuid}`,
+                            )
                         }
                     }
                 }}

--- a/src/app/(auth)/systems/users/[uuid]/_parts/user-form.tsx
+++ b/src/app/(auth)/systems/users/[uuid]/_parts/user-form.tsx
@@ -76,7 +76,7 @@ const UserForm = () => {
                         if (uuid) {
                             mutate(`users/${uuid}`)
                         } else {
-                            push('/users/' + res.data)
+                            push(`/systems/users/${res.data}`)
                         }
                         handleClose()
                     })

--- a/src/app/(auth)/systems/users/page.tsx
+++ b/src/app/(auth)/systems/users/page.tsx
@@ -44,15 +44,12 @@ export default function Page() {
                         viewColumns={false}
                         onRowClick={(data, _, { detail }) => {
                             if (detail === 2) {
-                                push(
-                                    '/systems/users/' +
-                                        /**
-                                         * data[1] is the UUID. declared on `DATATABLE_COLUMNS`
-                                         */
-                                        data[1] +
-                                        '?role=' +
-                                        selectedRole,
-                                )
+                                /**
+                                 * data[1] is the UUID. declared on {@link DATATABLE_COLUMNS}
+                                 */
+                                const uuid = data[1]
+
+                                push(`/systems/users/${uuid}?role=selectedRole`)
                             }
                         }}
                         tableId="users-table"

--- a/src/app/(guest)/password-reset/[token]/page.tsx
+++ b/src/app/(guest)/password-reset/[token]/page.tsx
@@ -48,18 +48,17 @@ export default function Page({
 
         axios
             .post('reset-password', formData)
-            .then(() =>
-                push(
-                    '/login?response=' +
-                        btoa(
-                            JSON.stringify({
-                                status: 201,
-                                message:
-                                    'Kata sandi berhasil diatur ulang. Silakan melakukan login dengan kata sandi baru Anda.',
-                            }),
-                        ),
-                ),
-            )
+            .then(() => {
+                const response = btoa(
+                    JSON.stringify({
+                        status: 201,
+                        message:
+                            'Kata sandi berhasil diatur ulang. Silakan melakukan login dengan kata sandi baru Anda.',
+                    }),
+                )
+
+                push(`/login?response=${response}`)
+            })
             .catch((err: AxiosError<LaravelValidationException>) => {
                 const { response } = err
 

--- a/src/app/(public)/public/profile/[userUuid]/page.tsx
+++ b/src/app/(public)/public/profile/[userUuid]/page.tsx
@@ -3,7 +3,7 @@
 // vendors
 import type { AxiosError } from 'axios'
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { notFound, useRouter } from 'next/navigation'
 import Head from 'next/head'
 // materials
 import Typography from '@mui/material/Typography'
@@ -33,7 +33,7 @@ export default function Page({
                 .then(res => setUser(res.data))
                 .catch((err: AxiosError) => {
                     if (err.status === 404) {
-                        replace('/404')
+                        notFound()
                     } else {
                         setError(err.message)
                     }

--- a/src/components/auth-layout/_parts/nav-bar/NAV_ITEM_GROUPS/systems.ts
+++ b/src/components/auth-layout/_parts/nav-bar/NAV_ITEM_GROUPS/systems.ts
@@ -2,7 +2,7 @@
 import type NavItemGroup from '../types/nav-item-group'
 // icons-materials
 import GroupIcon from '@mui/icons-material/Group'
-import SettingsIcon from '@mui/icons-material/Settings'
+// import SettingsIcon from '@mui/icons-material/Settings'
 // enums
 import Role from '@/enums/role'
 
@@ -15,11 +15,11 @@ export const systemsNavItemGroup: NavItemGroup = {
             icon: GroupIcon,
             forRole: Role.USER_ADMIN,
         },
-        {
-            href: '/systems/settings',
-            label: 'Pengaturan',
-            icon: SettingsIcon,
-            forRole: Role.SYSTEM_CONFIGURATOR,
-        },
+        // {
+        //     href: '/systems/settings',
+        //     label: 'Pengaturan',
+        //     icon: SettingsIcon,
+        //     forRole: Role.SYSTEM_CONFIGURATOR,
+        // },
     ],
 }

--- a/src/components/auth-layout/_parts/nav-bar/_parts/item-group/_parts/list-item.tsx
+++ b/src/components/auth-layout/_parts/nav-bar/_parts/item-group/_parts/list-item.tsx
@@ -11,6 +11,7 @@ import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 // icons
 import ArrowRightIcon from '@mui/icons-material/ArrowRight'
+import Link from 'next/link'
 
 export default function NavBarListItem({
     data,
@@ -36,6 +37,7 @@ export default function NavBarListItem({
                 py: 0,
             }}>
             <ListItemButton
+                LinkComponent={Link}
                 href={href}
                 disabled={isActive}
                 selected={isActive}

--- a/src/components/line-chart-card.tsx
+++ b/src/components/line-chart-card.tsx
@@ -1,0 +1,30 @@
+import LineChart from '@/components/Chart/Line'
+import StatCard from '@/components/StatCard'
+import type SectionData from '@/types/section-data'
+
+export default function LineChartCard({
+    title,
+    data,
+    collapsible,
+    ...rest
+}: SectionData['lineChart'] & { suffix?: string; collapsible?: boolean }) {
+    const isHigherThanPrevious =
+        data[data.length - 1].value > data[data.length - 2].value
+
+    return (
+        <StatCard
+            title={title}
+            collapsible={collapsible}
+            color={isHigherThanPrevious ? 'success' : 'error'}>
+            <LineChart
+                {...rest}
+                data={data}
+                lineProps={{
+                    stroke: isHigherThanPrevious
+                        ? 'var(--mui-palette-success-main)'
+                        : 'var(--mui-palette-error-main)',
+                }}
+            />
+        </StatCard>
+    )
+}

--- a/src/components/redirect-if-auth.ts
+++ b/src/components/redirect-if-auth.ts
@@ -1,5 +1,7 @@
 'use client'
+
 import useAuthInfo from '@/hooks/use-auth-info'
+import type { Route } from 'next'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 
@@ -21,7 +23,8 @@ function useAuthOnly() {
             pathname &&
             !['/logout', '/policy'].includes(pathname)
         ) {
-            const redirectTo = searchParams?.get('redirectTo') ?? '/dashboard'
+            const redirectTo =
+                (searchParams?.get('redirectTo') as Route) ?? '/dashboard'
 
             replace(redirectTo)
         }

--- a/src/components/redirect-if-unauth.ts
+++ b/src/components/redirect-if-unauth.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 // providers
 import useAuthInfo from '@/hooks/use-auth-info'
+import type { Route } from 'next'
 
 export default function RedirectIfUnauth() {
     const { push } = useRouter()
@@ -13,7 +14,7 @@ export default function RedirectIfUnauth() {
     useEffect(() => {
         if (!pathname || authInfo) return
 
-        const toLocation = ['/logout', '/policy'].includes(pathname)
+        const toLocation: Route = ['/logout', '/policy'].includes(pathname)
             ? '/'
             : `/login?redirectTo=${pathname}`
 

--- a/src/modules/user/hooks/use-user-detail-swr.ts
+++ b/src/modules/user/hooks/use-user-detail-swr.ts
@@ -14,7 +14,9 @@ export default function useUserDetailSwr() {
 
     return useSWR<UserORM>(uuid ? `users/${uuid}` : null, null, {
         onError: () => {
-            replace('/systems/users?role=' + searchParams?.get('role'))
+            const role = searchParams?.get('role')
+
+            replace(`/systems/users?role=${role}`)
         },
     })
 }

--- a/src/providers/@statics/theme.tsx
+++ b/src/providers/@statics/theme.tsx
@@ -1,15 +1,7 @@
 'use client'
 
-import type { LinkProps } from 'next/link'
-import { forwardRef } from 'react'
 import { createTheme } from '@mui/material/styles'
 import Link from 'next/link'
-
-const LinkBehavior = forwardRef<HTMLAnchorElement, LinkProps>(
-    function LinkBehavior(props, ref) {
-        return <Link {...props} ref={ref} />
-    },
-)
 
 const THEME = createTheme({
     cssVariables: {
@@ -28,12 +20,12 @@ const THEME = createTheme({
     components: {
         MuiLink: {
             defaultProps: {
-                component: LinkBehavior,
+                component: Link,
             },
         },
         MuiButtonBase: {
             defaultProps: {
-                LinkComponent: LinkBehavior,
+                LinkComponent: Link,
             },
         },
     },

--- a/src/types/section-data.ts
+++ b/src/types/section-data.ts
@@ -1,0 +1,10 @@
+import type { BigNumberCardProps } from '@/components/big-number-card'
+
+export default interface SectionData {
+    bigNumber1: BigNumberCardProps
+    bigNumber2: BigNumberCardProps
+    lineChart: {
+        title: string
+        data: { label: string; value: number }[]
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,5 +37,5 @@
         ]
     },
     "include": ["**/*.mjs", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-    "exclude": [".next/**", "node_modules", "public/sw.js"]
+    "exclude": ["node_modules", "public/sw.js"]
 }


### PR DESCRIPTION
- Migrates string concatenations to template literals for constructing URLs and query parameters, enhancing code readability and maintainability.
- Updates `CardActionArea` and `ListItemButton` to use `LinkComponent={Link}` for `next/link` integration, aligning with Material-UI's recommended approach.
- Simplifies global Material-UI theme configuration for `Link` and `ButtonBase` by directly referencing `next/link/Link`, removing the custom `LinkBehavior` wrapper.
- Adopts `notFound()` from `next/navigation` for 404 error handling, improving consistency and leveraging Next.js's built-in features.
- Relocates `LineChartCard` component and `SectionData` type to shared utility files, promoting reusability across the application.
- Includes minor adjustments to query parameter clearing logic and removes an unused navigation item.

fix #751