### PR TITLE
Removes unnecessary React.memo from table parts

### DIFF
--- a/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-body.tsx
+++ b/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-body.tsx
@@ -1,14 +1,13 @@
 // types
 import type ProductSaleORM from '@/modules/farm-inputs/types/orms/product-sale'
 // vendors
-import { memo } from 'react'
 import MuiTableBody from '@mui/material/TableBody'
 import MuiTableRow from '@mui/material/TableRow'
 import TableCell from '@mui/material/TableCell'
 // components
 import TableRow from './table-row'
 
-function TableBody({ data }: { data: ProductSaleORM[] }) {
+export default function TableBody({ data }: { data: ProductSaleORM[] }) {
     return (
         <MuiTableBody
             sx={{
@@ -34,5 +33,3 @@ function TableBody({ data }: { data: ProductSaleORM[] }) {
         </MuiTableBody>
     )
 }
-
-export default memo(TableBody)

--- a/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-footer.tsx
+++ b/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-footer.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react'
 import MuiTableFooter from '@mui/material/TableFooter'
 import TableCell from '@mui/material/TableCell'
 import TableRow from '@mui/material/TableRow'
@@ -10,7 +9,7 @@ const LEFT_BORDER_STYLE = {
     borderLeft: '1px solid var(--mui-palette-TableCell-border)',
 }
 
-function TableFooter({ data }: { data: ProductSaleORM[] }) {
+export default function TableFooter({ data }: { data: ProductSaleORM[] }) {
     const baseCostTotalRp = data.reduce(
         (acc, row) =>
             acc +
@@ -87,8 +86,6 @@ function TableFooter({ data }: { data: ProductSaleORM[] }) {
         </MuiTableFooter>
     )
 }
-
-export default memo(TableFooter)
 
 function formatNumber(number: number) {
     return globalFormatNumber(number, {

--- a/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-head.tsx
+++ b/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-head.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react'
 import MuiTableHead from '@mui/material/TableHead'
 import TableCell from '@mui/material/TableCell'
 import TableRow from '@mui/material/TableRow'
@@ -7,7 +6,7 @@ const LEFT_BORDER_STYLE = {
     borderLeft: '1px solid var(--mui-palette-TableCell-border)',
 }
 
-function TableHead() {
+export default function TableHead() {
     return (
         <MuiTableHead
             sx={{
@@ -37,5 +36,3 @@ function TableHead() {
         </MuiTableHead>
     )
 }
-
-export default memo(TableHead)

--- a/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-row.tsx
+++ b/src/app/(auth)/farm-inputs/product-sales/reports/_parts/table/table-row.tsx
@@ -5,13 +5,13 @@ import toDmy from '@/utils/to-dmy'
 import ucWords from '@/utils/uc-words'
 import TableCell from '@mui/material/TableCell'
 import MuiTableRow from '@mui/material/TableRow'
-import { memo, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 
 const LEFT_BORDER_STYLE = {
     borderLeft: '1px solid var(--mui-palette-TableCell-border)',
 }
 
-function TableRow({
+export default function TableRow({
     data: {
         short_uuid,
         product_movement_details,
@@ -131,8 +131,6 @@ function TableRow({
         </MuiTableRow>
     )
 }
-
-export default memo(TableRow)
 
 function Ul({ children }: { children: ReactNode }) {
     return (


### PR DESCRIPTION
Removes `React.memo` from the table body, footer, head, and row components.

`React.memo` is often a premature optimization and can introduce overhead if props change frequently or if the prop comparison itself is complex. Removing it simplifies these components and ensures they re-render efficiently without the added cost of `memo`'s prop comparison.