### PR TITLE
Aligns user select field prop handling

### DIFF
--- a/src/components/formik-fields/user-select.tsx
+++ b/src/components/formik-fields/user-select.tsx
@@ -57,13 +57,13 @@ export default function UserSelect({
 }
 
 function InnerComponent({
-    name,
     disabled,
     label,
     slotProps,
 
+    field: { name },
     form: { setFieldValue, isSubmitting, status, getFieldMeta },
-}: Omit<FieldProps<string>, 'meta'> & UserSelectProps) {
+}: Omit<FieldProps<string>, 'meta'> & Omit<UserSelectProps, 'name'>) {
     const { error: errorMeta, value } = getFieldMeta<string>(name)
     const [textfieldValue, setTextFieldValue] = useState('')
     const { data: users = [], isLoading } = useSWR<ApiResponse>(
@@ -101,7 +101,7 @@ function InnerComponent({
                     : 'Ketik minimal 3 karakter'
             }
             disabled={
-                disabled || isSubmitting || isLoading || status.isDisabled
+                disabled || isSubmitting || isLoading || status?.isDisabled
             }
             value={selectedUser ?? null}
             filterOptions={(options, { inputValue }) => {


### PR DESCRIPTION
Refactors the `InnerComponent` to destructure the `name` prop directly from Formik's `field` object. This ensures consistent prop sourcing and clarifies the component's interface, aligning it more closely with standard Formik patterns.

Updates the component's prop types to reflect this change, explicitly omitting `name` from `UserSelectProps` when combined.

Adds optional chaining to `status?.isDisabled` for improved robustness, preventing potential errors if the `status` object is undefined to fix EKBS-NEXTJS-7T.