### PR TITLE
Handles optional spare part margins

### DIFF
--- a/src/modules/repair-shop/types/sale-form-values.ts
+++ b/src/modules/repair-shop/types/sale-form-values.ts
@@ -31,7 +31,7 @@ export default interface SaleFormValues {
         rp_per_unit: number
     }>[]
 
-    spare_part_margins: {
+    spare_part_margins?: {
         spare_part_warehouse_id: number
         margin_percentage: number
     }[]

--- a/src/modules/repair-shop/utils/calculate-totals.ts
+++ b/src/modules/repair-shop/utils/calculate-totals.ts
@@ -21,11 +21,12 @@ export default function calculateTotals({
     const totalRpWithoutInterest =
         totalMovementRp + totalServiceRp + (adjustment_rp ?? 0)
 
-    const sparePartInterestPercent = spare_part_margins.reduce(
-        (acc, { margin_percentage }) =>
-            acc + margin_percentage / spare_part_margins.length,
-        0,
-    )
+    const sparePartInterestPercent =
+        spare_part_margins?.reduce(
+            (acc, { margin_percentage }) =>
+                acc + margin_percentage / spare_part_margins.length,
+            0,
+        ) ?? 0
 
     const totalInterest =
         payment_method === 'installment'


### PR DESCRIPTION
Allows `spare_part_margins` to be optional in sale forms.

Updates total calculation to safely handle cases where margins are not provided, defaulting the interest percentage to zero and preventing potential runtime errors.