### PR TITLE
Safely handles optional installment parent data

### DIFF
--- a/src/app/(auth)/repair-shop/sales/_parts/components/receipt.tsx
+++ b/src/app/(auth)/repair-shop/sales/_parts/components/receipt.tsx
@@ -9,7 +9,7 @@ import Typography from '@mui/material/Typography'
 import formatNumber from '@/utils/format-number'
 // assets
 // import martLogo from '@/../public/assets/images/belayan-mart-logo.jpg'
-import type { Sale } from '../../../../../../modules/repair-shop/types/orms/sale'
+import type { Sale } from '@/modules/repair-shop/types/orms/sale'
 import type SparePartMovement from '@/modules/repair-shop/types/orms/spare-part-movement'
 // utils
 import shortUuid from '@/utils/short-uuid'
@@ -28,7 +28,7 @@ export default function Receipt({ data }: { data: Sale }) {
         data.spare_part_margins?.reduce(
             (acc, { margin_rp }) => acc + margin_rp,
             0,
-        ) ?? 0 * data.installment_parent.n_term
+        ) ?? 0 * (data?.installment_parent?.n_term ?? 0)
 
     return (
         <Box

--- a/src/modules/repair-shop/types/orms/sale.ts
+++ b/src/modules/repair-shop/types/orms/sale.ts
@@ -72,7 +72,7 @@ type SalePayment =
           payment_method: 'installment'
           transaction?: never
           installments: InstallmentORM[]
-          installment_parent: {
+          installment_parent?: {
               id: number
               n_term: number
               term_unit: 'minggu' | 'bulan'


### PR DESCRIPTION
Ensures robust calculation of installment-related values on sales receipts by making the `installment_parent` property optional in the `SalePayment` type. This change incorporates optional chaining and nullish coalescing to prevent runtime errors when `installment_parent` or its `n_term` property is undefined. Also updates an import path for consistency.