### PR TITLE
Refactors spare part installment margin property to fix wrong/outdated field name

### DIFF
--- a/src/app/(auth)/repair-shop/spare-parts/_parts/form-dialog.tsx
+++ b/src/app/(auth)/repair-shop/spare-parts/_parts/form-dialog.tsx
@@ -33,7 +33,7 @@ export type FormData = Partial<{
     /**
      * margin percent should be per warehouse not per spare part but it's ok for now
      */
-    margin_percent_installment: number
+    installment_margin_percent: number
     vehicle_type: 'motorcycle' | 'car'
     deleted_at: string
 }>
@@ -178,7 +178,6 @@ function SparePartFormikForm({
                 <NumericField
                     name="installment_margin_percent"
                     label="Marjin Default Angsuran"
-                    disabled={isSubmitting}
                     numericFormatProps={{
                         slotProps: {
                             input: {

--- a/src/app/(auth)/repair-shop/spare-parts/page.tsx
+++ b/src/app/(auth)/repair-shop/spare-parts/page.tsx
@@ -72,7 +72,7 @@ export default function Page() {
                                 ...data,
                                 margin_percent:
                                     data.warehouses[0].margin_percent,
-                                margin_percent_installment:
+                                installment_margin_percent:
                                     data.warehouses[0]
                                         .installment_margin_percent,
                             } satisfies Required<FormData>)


### PR DESCRIPTION
Renames the `margin_percent_installment` property to `installment_margin_percent` for improved consistency across data structures and forms.

Also removes the `disabled` attribute from the installment margin percent input field during form submission, allowing user interaction.