### PR TITLE
Refines spare part movement detail ORM

### DIFF
--- a/src/modules/repair-shop/types/orms/spare-part-movement.ts
+++ b/src/modules/repair-shop/types/orms/spare-part-movement.ts
@@ -23,22 +23,61 @@ export default interface SparePartMovementORM {
     costs: []
 }
 
+/**
+ * @see [ProductMovementDetail Eloquent](https://github.com/sensasi-apps/ekbs-laravel/blob/main/Modules/RepairShop/app/Models/SparePartMovementDetail.php)
+ */
 interface Detail {
+    /**
+     * [💾]
+     *
+     *  @readonly
+     */
     id: number
 
+    /**
+     * [💾]
+     *
+     *  @readonly
+     */
     spare_part_movement_uuid: SparePartMovementORM['uuid']
 
     /**
-     * relation
+     * [💾]
+     */
+    spare_part_id: SparePartORM['id']
+
+    /**
+     * [💾]
+     */
+    qty: number
+
+    /**
+     * [💾]
+     */
+    rp_per_unit: number
+
+    /**
+     * [💾]
+     */
+    cost_rp_per_unit: number
+
+    /**
+     * [💾]
+     */
+    spare_part_state: SparePartORM | null
+
+    /**
+     * [💾]
+     */
+    spare_part_warehouse_id: number
+
+    /**
+     * [🔗]
      */
     spare_part_movement?: SparePartMovementORM
 
-    spare_part_id: SparePartORM['id']
+    /**
+     * [🔗]
+     */
     spare_part: SparePartORM
-
-    qty: number
-    rp_per_unit: number
-    cost_rp_per_unit: number
-
-    spare_part_state: SparePartORM | null
 }


### PR DESCRIPTION
Enhances the `SparePartMovementDetail` interface with improved documentation and type accuracy.

Adds JSDoc comments to clearly distinguish between stored (`[💾]`) and relation (`[🔗]`) properties, improving clarity on data persistence. Incorporates the missing `spare_part_warehouse_id` field and marks identifier properties as `readonly`.

Includes a direct reference to the backend Eloquent model for better cross-module consistency.