### PR TITLE
Adds receivables page for repair shop

### DIFF
--- a/src/app/(auth)/finances/receivables/page.tsx
+++ b/src/app/(auth)/finances/receivables/page.tsx
@@ -6,6 +6,10 @@ import FormatAlignJustifyIcon from '@mui/icons-material/FormatAlignJustify'
 import PageTitle from '@/components/page-title'
 import ReceivablesDatatable from '@/components/ReceivablesDatatable'
 
+export const metadata = {
+    title: `Piutang — ${process.env.NEXT_PUBLIC_APP_NAME}`,
+}
+
 export default function Receivables() {
     return (
         <>

--- a/src/app/(auth)/repair-shop/receivables/page.tsx
+++ b/src/app/(auth)/repair-shop/receivables/page.tsx
@@ -1,0 +1,18 @@
+// components
+import PageTitle from '@/components/page-title'
+import ReceivablesDatatable from '@/components/ReceivablesDatatable'
+import BusinessUnit from '@/enums/business-unit'
+
+export const metadata = {
+    title: `Piutang Belayan Spare Parts — ${process.env.NEXT_PUBLIC_APP_NAME}`,
+}
+
+export default function Receivables() {
+    return (
+        <>
+            <PageTitle title="Piutang" subtitle="Belayan Spare Parts" />
+
+            <ReceivablesDatatable asManager type={BusinessUnit.BENGKEL} />
+        </>
+    )
+}

--- a/src/components/ReceivablesDatatable/ReceivablesDatatable.tsx
+++ b/src/components/ReceivablesDatatable/ReceivablesDatatable.tsx
@@ -16,7 +16,7 @@ import shortUuid from '@/utils/short-uuid'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 // components
-import Datatable from '@/components/Datatable'
+import Datatable, { getNoWrapCellProps } from '@/components/Datatable'
 import Dialog from '../Global/Dialog'
 // locals
 import { useHooks } from './hooks/useHooks'
@@ -29,6 +29,7 @@ import handle422 from '@/utils/handle-422'
 import ReceivablePaymentForm from './PaymentForm'
 import formatNumber from '@/utils/format-number'
 import getInstallmentColor from '@/utils/get-installment-color'
+import type BusinessUnit from '@/enums/business-unit'
 
 const DATATABLE_ENDPOINT_URL = 'receivables/datatable-data'
 
@@ -40,7 +41,11 @@ export default function ReceivablesDatatable({
     type: typeProp,
 }: {
     asManager?: boolean
-    type?: 'rent-item-rent' | 'product-sale' | 'user-loan'
+    type?:
+        | 'rent-item-rent'
+        | 'product-sale'
+        | 'user-loan'
+        | BusinessUnit.BENGKEL
 }) {
     const { type, state, formikProps, closeFormDialog, setFormikProps } =
         useHooks()
@@ -170,6 +175,7 @@ const DATATABLE_COLUMNS: DatatableProps<InstallmentORM>['columns'] = [
         name: 'at',
         label: 'TGL. Transaksi',
         options: {
+            setCellProps: getNoWrapCellProps,
             searchable: false,
             sort: false,
         },
@@ -202,12 +208,7 @@ const DATATABLE_COLUMNS: DatatableProps<InstallmentORM>['columns'] = [
         label: 'Nilai (Rp)',
         options: {
             searchable: false,
-            setCellProps: () => ({
-                style: {
-                    whiteSpace: 'nowrap',
-                    textAlign: 'right',
-                },
-            }),
+            setCellProps: getNoWrapCellProps,
             customBodyRender: (value: number) => formatNumber(value),
         },
     },
@@ -216,6 +217,9 @@ const DATATABLE_COLUMNS: DatatableProps<InstallmentORM>['columns'] = [
     {
         name: 'should_be_paid_at',
         label: 'Jatuh Tempo',
+        options: {
+            setCellProps: getNoWrapCellProps,
+        },
     },
 
     // Current State
@@ -263,5 +267,8 @@ function getInstallmentTypeByClassname(classname: string) {
 
         case 'App\\Models\\RentItemRent':
             return 'Sewa Alat Berat'
+
+        case 'Modules\\RepairShop\\Models\\Sale':
+            return 'Belayan Spare Parts'
     }
 }

--- a/src/components/ReceivablesDatatable/components/type-filter-chips.tsx
+++ b/src/components/ReceivablesDatatable/components/type-filter-chips.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import Chip from '@mui/material/Chip'
 // components
 import ScrollableXBox from '@/components/ScrollableXBox'
+import BusinessUnit from '@/enums/business-unit'
 
 export default function TypeFilterChips() {
     const searchParams = useSearchParams()
@@ -48,6 +49,17 @@ export default function TypeFilterChips() {
                 color={type === 'rent-item-rent' ? 'success' : undefined}
                 href={`?type=rent-item-rent&state=${state}`}
                 clickable={type !== 'rent-item-rent'}
+                component={Link}
+                size="small"
+            />
+
+            <Chip
+                label="Belayan Spare Parts"
+                color={
+                    type === `${BusinessUnit.BENGKEL}` ? 'success' : undefined
+                }
+                href={`?type=${BusinessUnit.BENGKEL}&state=${state}`}
+                clickable={type !== `${BusinessUnit.BENGKEL}`}
                 component={Link}
                 size="small"
             />

--- a/src/components/auth-layout/_parts/nav-bar/NAV_ITEM_GROUPS/repair-shop.ts
+++ b/src/components/auth-layout/_parts/nav-bar/NAV_ITEM_GROUPS/repair-shop.ts
@@ -3,6 +3,7 @@ import type NavItemGroup from '../types/nav-item-group'
 import TopicIcon from '@mui/icons-material/Topic'
 import CartIcon from '@mui/icons-material/ShoppingCart'
 import PointOfSaleIcon from '@mui/icons-material/PointOfSale'
+import SavingsIcon from '@mui/icons-material/Savings'
 // enums
 import PurchasePermission from '@/app/(auth)/repair-shop/spare-part-purchases/_parts/enums/permission'
 import SparePartPermission from '@/modules/repair-shop/enums/permission'
@@ -36,6 +37,13 @@ export const repairShop: NavItemGroup = {
             href: '/repair-shop/services',
             icon: TopicIcon,
             forPermission: ServicePermission.READ,
+        },
+
+        {
+            label: 'Piutang',
+            href: '/repair-shop/receivables',
+            icon: SavingsIcon,
+            forPermission: SalePermission.READ,
         },
 
         {

--- a/src/enums/installment-installemtable-classname.ts
+++ b/src/enums/installment-installemtable-classname.ts
@@ -1,0 +1,8 @@
+enum InstallmentTnstallmentableClassname {
+    USER_LOAN = 'App\\Models\\UserLoan',
+    PRODUCT_SALE = 'App\\Models\\ProductSale',
+    RENT_ITEM_RENT = 'App\\Models\\RentItemRent',
+    REPAIR_SHOP_SALE = 'Modules\\RepairShop\\Models\\Sale',
+}
+
+export default InstallmentTnstallmentableClassname

--- a/src/modules/installment/types/orms/installment.ts
+++ b/src/modules/installment/types/orms/installment.ts
@@ -4,6 +4,7 @@ import type ProductSaleORM from '@/modules/farm-inputs/types/orms/product-sale'
 import type RentItemRent from '@/types/orms/rent-item-rent'
 import type TransactionORM from '@/modules/transaction/types/orms/transaction'
 import type UserLoanORM from '@/modules/installment/types/orms/user-loan'
+import type InstallmentTnstallmentableClassname from '@/enums/installment-installemtable-classname'
 
 export default interface InstallmentORM {
     uuid: UUID
@@ -20,6 +21,8 @@ export default interface InstallmentORM {
         | 'App\\Models\\UserLoan'
         | 'App\\Models\\ProductSale'
         | 'App\\Models\\RentItemRent'
+        | 'Modules\\RepairShop\\Models\\Sale'
+        | InstallmentTnstallmentableClassname
     installmentable?: UserLoanORM | ProductSaleORM | RentItemRent
     user_loan?: UserLoanORM
     product_sale?: ProductSaleORM


### PR DESCRIPTION
Adds a new receivables page specifically for the repair shop's "Belayan Spare Parts" business unit.

This page includes:
- A dedicated route under `/repair-shop/receivables`
- A page title indicating "Piutang Belayan Spare Parts"
- Integration with the existing `ReceivablesDatatable` component, configured to display receivables data related to the repair shop.
- Adds a filter chip to the receivables datatable to filter by "Belayan Spare Parts"
- Adds navigation item to the repair shop navigation menu

The datatable component is enhanced to handle different business units and display data accordingly. It also includes minor styling adjustments for better readability.