### PR TITLE
Refines spare part array field and form submission

### DIFF
--- a/src/app/(auth)/repair-shop/sales/_parts/components/spare-parts-array-field.tsx
+++ b/src/app/(auth)/repair-shop/sales/_parts/components/spare-parts-array-field.tsx
@@ -106,6 +106,7 @@ export default function SparePartsArrayField({
                                                             selected?.spare_part_warehouse_id,
                                                         rp_per_unit:
                                                             selected?.default_sell_price,
+                                                        qty: row.qty,
                                                     },
                                                 )
 
@@ -231,12 +232,20 @@ function NumberCell({
     remove: (index: number) => void
     showDelete: boolean
 }) {
+    const { setFieldValue, values } = useFormikContext<SaleFormValues>()
     if (!showDelete) return index + 1
 
     return (
         <>
             <RemoveButton
-                onClick={() => remove(index)}
+                onClick={() => {
+                    remove(index)
+
+                    setFieldValue(`spare_part_margins`, [
+                        ...(values.spare_part_margins?.slice(0, index) ?? []),
+                        ...(values.spare_part_margins?.slice(index + 1) ?? []),
+                    ])
+                }}
                 isDisabled={isDisabled}
             />
 

--- a/src/modules/repair-shop/components/spare-part-formik-field.tsx
+++ b/src/modules/repair-shop/components/spare-part-formik-field.tsx
@@ -52,7 +52,7 @@ function InnerComponent({
     isDisabled,
 
     field: { name },
-    form: { getFieldMeta, status },
+    form: { getFieldMeta, status, isSubmitting },
 }: Omit<FieldProps<number>, 'meta'> & {
     onChange: OnChangeType
     isDisabled?: boolean
@@ -84,7 +84,7 @@ function InnerComponent({
             value={selectedValue}
             options={spareParts}
             getOptionDisabled={sparePart => sparePart.qty <= 0}
-            disabled={isDisabled || status?.isDisabled}
+            disabled={isDisabled || status?.isDisabled || isSubmitting}
             getOptionLabel={sparePart =>
                 `${sparePart.spare_part_id} — ${sparePart.name}`
             }


### PR DESCRIPTION
Adds quantity to the spare part margin object upon selection, ensuring complete data for calculations.

Synchronizes Formik's `spare_part_margins` array when an item is removed from the array field, preventing data inconsistencies.

Disables the spare part selection field during form submission to prevent unintended modifications.