### PR TITLE
Add total payment validation and refine repair price calculation

### DIFF
--- a/src/components/pages/marts/products/sales/formik-wrapper/statics/validation-scheme.ts
+++ b/src/components/pages/marts/products/sales/formik-wrapper/statics/validation-scheme.ts
@@ -36,6 +36,11 @@ export const VALIDATION_SCHEMA = yup.object().shape({
     total_payment: yup
         .number()
         .required('Total pembayaran tidak boleh kosong')
+        .min(1, 'Total pembayaran tidak boleh nol')
+        .max(
+            1000000000,
+            'Total pembayaran tidak boleh lebih dari 1.000.000.000',
+        )
         .when(['details', 'costs'], (data: Array<unknown>, schema) => {
             const details = data[0] as FormValuesType['details']
             const costs = data[1] as FormValuesType['costs']

--- a/src/modules/repair-shop/utils/calculate-totals.ts
+++ b/src/modules/repair-shop/utils/calculate-totals.ts
@@ -33,18 +33,15 @@ export default function calculateTotals({
 
                       if (!sparePart?.qty || !sparePart?.rp_per_unit) return 0
 
-                      return Math.ceil(
-                          (sparePart.qty *
-                              sparePart.rp_per_unit *
-                              margin_percentage) /
-                              100,
-                      )
+                      const marginRate = margin_percentage / 100
+
+                      return sparePart.qty * sparePart.rp_per_unit * marginRate
                   })
                   .reduce((acc, cur) => acc + cur, 0) ?? 0) *
               installment_data.n_term
             : 0
 
-    const totalRp = totalRpWithoutInterest + totalInterest
+    const totalRp = Math.ceil(totalRpWithoutInterest + totalInterest)
 
     return {
         totalMovementRp,


### PR DESCRIPTION
Implement validation for total payment to ensure it is a positive value within a specified limit. Adjust the rounding strategy for repair shop totals to improve precision in calculations.