### PR TITLE
Sorts transactions by timestamp in the transaction CRUD component.

### DIFF
--- a/src/app/(auth)/finances/cashes/_parts/transaction/crud.tsx
+++ b/src/app/(auth)/finances/cashes/_parts/transaction/crud.tsx
@@ -63,7 +63,7 @@ export default function TransactionCrud() {
             <Datatable<CustomTx>
                 apiUrl="/transactions/datatable"
                 columns={DATATABLE_COLUMNS}
-                defaultSortOrder={{ name: 'uuid', direction: 'desc' }}
+                defaultSortOrder={{ name: 'at', direction: 'desc' }}
                 download
                 getRowDataCallback={fn => (getRowDataRef.current = fn)}
                 onRowClick={handleRowClick}


### PR DESCRIPTION
This commit updates the default sort order in the transaction CRUD component to sort transactions by timestamp in descending order, improving the ordering and filtering capabilities.