### PR TITLE
Improves datatable search behavior

### DIFF
--- a/src/app/(auth)/repair-shop/sales/page-client.tsx
+++ b/src/app/(auth)/repair-shop/sales/page-client.tsx
@@ -26,34 +26,32 @@ export default function PageClient() {
     const { push } = useRouter()
     getRowDataRef = useRef<GetRowDataType<Sale> | undefined>(undefined)
     return (
-        <>
-            <Datatable<Sale>
-                apiUrl="repair-shop/sales/datatable"
-                columns={DATATABLE_COLUMNS}
-                defaultSortOrder={{ name: 'uuid', direction: 'desc' }}
-                getRowDataCallback={fn => {
-                    getRowDataRef.current = fn
-                }}
-                onRowClick={(_, { dataIndex }, event) => {
-                    if (event.detail === 2) {
-                        const data = getRowDataRef.current?.(dataIndex)
+        <Datatable<Sale>
+            apiUrl="repair-shop/sales/datatable"
+            columns={DATATABLE_COLUMNS}
+            defaultSortOrder={{ name: 'uuid', direction: 'desc' }}
+            getRowDataCallback={fn => {
+                getRowDataRef.current = fn
+            }}
+            onRowClick={(_, { dataIndex }, event) => {
+                if (event.detail === 2) {
+                    const data = getRowDataRef.current?.(dataIndex)
 
-                        if (!data) return
+                    if (!data) return
 
-                        push(`/repair-shop/sales/${data.uuid}`)
-                    }
-                }}
-                title="Riwayat"
-                tableId="sales-datatable"
-            />
-        </>
+                    push(`/repair-shop/sales/${data.uuid}`)
+                }
+            }}
+            title="Riwayat"
+            tableId="sales-datatable"
+        />
     )
 }
 
 const DATATABLE_COLUMNS: DatatableProps<Sale>['columns'] = [
     {
         name: 'uuid',
-        label: 'kode',
+        label: 'Kode',
         options: {
             customBodyRender(value: string) {
                 return <TextShortener text={value} />


### PR DESCRIPTION
Refactors the datatable's search input handlers to extract logic into a dedicated helper function.

Resets the datatable's pagination to the first page when a search is performed, ensuring a consistent user experience.

Includes minor UI cleanup by removing a redundant fragment and capitalizing a column label.