### PR TITLE
Improves search input event handling

### DIFF
--- a/src/components/Datatable/hooks/use-hooks.ts
+++ b/src/components/Datatable/hooks/use-hooks.ts
@@ -78,9 +78,9 @@ export default function useHooks<T>(
         sortOrder: sortOrder,
         searchProps: {
             onKeyUp: (ev: KeyboardEvent<HTMLInputElement>) => {
-                if (ev.key === 'Enter') {
+                if (ev.key === 'Enter' && 'value' in ev.target) {
                     handleSearchChange(
-                        ev.currentTarget.value,
+                        ev.target.value as string,
                         lastDataTableState,
                         setDatatableSentRequestParamJson,
                     )


### PR DESCRIPTION
Enhances robustness for search input event handling by ensuring the `value` property exists on the event target before attempting to access it. This prevents potential runtime errors and improves type safety when capturing the input value on an 'Enter' key press.

fix EKBS-LARAVEL-BE