### PR TITLE
Upgrades mui-datatable-delight dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "jotai": "^2.15.0",
         "js-file-download": "^0.4.12",
         "js-sha3": "^0.9.3",
-        "mui-datatable-delight": "^2.0.0-experimental.2",
+        "mui-datatable-delight": "2.0.0-experimental.7",
         "next": "^15.5.4",
         "notistack": "^3.0.2",
         "qs": "^6.14.0",
@@ -1654,7 +1654,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "mui-datatable-delight": ["mui-datatable-delight@2.0.0-experimental.2", "", { "dependencies": { "@emotion/react": "^11.14.0", "@emotion/styled": "^11.14.1", "@mui/icons-material": "^7.3.4", "@mui/material": "^7.3.4", "react": "19.2.0", "react-dom": "19.2.0", "react-fast-compare": "^3.2.2", "react-to-print": "^3.1.1", "tss-react": "^4.9.19" } }, "sha512-kqn5bRCF8f1IazxpN2GOFMHnlzMkSiCcSByu+jJt+fDzMybzi4RhtKN+hCTS3tMOCtPqNHKOM2dVWdzADmZjRw=="],
+    "mui-datatable-delight": ["mui-datatable-delight@2.0.0-experimental.7", "", { "dependencies": { "@emotion/react": "^11.4.1", "@emotion/styled": "^11.4.1", "@mui/icons-material": "^7.3", "@mui/material": "^7.3", "react": "^18.3.1 || ^19", "react-dom": "^18.3.1 || ^19", "react-fast-compare": "^3.2.2", "react-to-print": "^3.0.5", "redux": "^4.2.0", "tss-react": "^4.9.14" } }, "sha512-m6qW43ZqKkQZ9xw6rdQ+wdZhS1VMcxXlwlpPhr/fT8NRmDKDbricQh2A/4mlgjXzV61P/Pqt1VpvRwOvEXxtfw=="],
 
     "multipipe": ["multipipe@1.0.2", "", { "dependencies": { "duplexer2": "^0.1.2", "object-assign": "^4.1.0" } }, "sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ=="],
 
@@ -1849,6 +1849,8 @@
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "redux": ["redux@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.9.2" } }, "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -2545,6 +2547,8 @@
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "recharts/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "redux/@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
     "require-in-the-middle/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "jotai": "^2.15.0",
         "js-file-download": "^0.4.12",
         "js-sha3": "^0.9.3",
-        "mui-datatable-delight": "^2.0.0-experimental.2",
+        "mui-datatable-delight": "2.0.0-experimental.7",
         "next": "^15.5.4",
         "notistack": "^3.0.2",
         "qs": "^6.14.0",


### PR DESCRIPTION
Updates the `mui-datatable-delight` package to `2.0.0-experimental.2`.

This upgrade brings various dependency updates, including newer versions of `@mui` and `@emotion` components, and aligns the `react` and `react-dom` peer dependencies to a specific version for improved compatibility.