### PR TITLE
Updates `mui-datatable-delight` package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "jotai": "^2.15.0",
         "js-file-download": "^0.4.12",
         "js-sha3": "^0.9.3",
-        "mui-datatable-delight": "2.0.0-experimental.17",
+        "mui-datatable-delight": "2.0.0-experimental.18",
         "next": "^15.5.6",
         "notistack": "^3.0.2",
         "qs": "^6.14.0",
@@ -1654,7 +1654,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "mui-datatable-delight": ["mui-datatable-delight@2.0.0-experimental.17", "", { "dependencies": { "@emotion/react": "^11.14.0", "@emotion/styled": "^11.14.1", "@mui/icons-material": "^7.3.4", "@mui/material": "^7.3.4", "react": "^19.2.0", "react-dom": "^19.2.0", "react-fast-compare": "^3.2.2", "react-to-print": "^3.2.0" } }, "sha512-b+o/GcA6XRDGYHoudb88s7c1SPtVgnRWpobDRHMoWAzKM26TrDIfz+byKm8mP5GCsG++FYqrYXIz+U8DX1t04A=="],
+    "mui-datatable-delight": ["mui-datatable-delight@2.0.0-experimental.18", "", { "dependencies": { "@emotion/react": "^11.14.0", "@emotion/styled": "^11.14.1", "@mui/icons-material": "^7.3.4", "@mui/material": "^7.3.4", "react": "^19.2.0", "react-dom": "^19.2.0", "react-fast-compare": "^3.2.2", "react-to-print": "^3.2.0" } }, "sha512-eQL/DTWROkkasPSMl/MlhOAQWY4t9uyHl7xHGtj2cI4Pbd6hfxXZDpW5a5yFjF3oRNOG7ZRWFlqv6CrG727S/A=="],
 
     "multipipe": ["multipipe@1.0.2", "", { "dependencies": { "duplexer2": "^0.1.2", "object-assign": "^4.1.0" } }, "sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "jotai": "^2.15.0",
         "js-file-download": "^0.4.12",
         "js-sha3": "^0.9.3",
-        "mui-datatable-delight": "2.0.0-experimental.17",
+        "mui-datatable-delight": "2.0.0-experimental.18",
         "next": "^15.5.6",
         "notistack": "^3.0.2",
         "qs": "^6.14.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "strict": true,
-        "target": "ES2017",
+        "target": "ES2018",
         "types": ["@serwist/next/typings"],
         "verbatimModuleSyntax": true
     },


### PR DESCRIPTION
Upgrades the `mui-datatable-delight` dependency to a newer experimental version (`2.0.0-experimental.17`). This update also includes an upgrade to `react-to-print` from `3.1.1` to `3.2.0`.