### PR TITLE
Ensures accurate print content on mobile

### DIFF
--- a/src/components/print-handler.tsx
+++ b/src/components/print-handler.tsx
@@ -93,14 +93,13 @@ function handlePrintMobile(contentRef: RefObject<HTMLElement | null>) {
         printWindow.document.body.classList.add(className)
     })
 
-    printWindow.document.body.innerHTML = contentRef.current.innerHTML
+    printWindow.document.body.appendChild(contentRef.current.cloneNode(true))
 
     printWindow.document.close()
 
-    printWindow.onload = () => {
-        printWindow.focus()
-        setTimeout(() => {
-            printWindow.print()
-        }, 300)
-    }
+    printWindow.focus()
+
+    setTimeout(() => {
+        printWindow.print()
+    }, 500)
 }


### PR DESCRIPTION
Updates how content is transferred to the print window by using `cloneNode(true)` instead of `innerHTML`. This preserves event listeners, script tags, and other dynamic elements, providing a more faithful representation of the original content.

Removes the reliance on the `onload` event for the print window, which can be unreliable. Focus and print calls are now executed directly, improving the responsiveness and consistency of the print flow. The print timeout is also slightly increased to allow for better rendering.