### PR TITLE
Refactors dashboard and adds online users page

### DIFF
--- a/src/app/(auth)/(superman)/online-users/page.tsx
+++ b/src/app/(auth)/(superman)/online-users/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import RefreshIcon from '@mui/icons-material/Refresh'
+import LinearProgress from '@mui/material/LinearProgress'
+import TextField from '@mui/material/TextField'
+import { useState } from 'react'
+import useSWR from 'swr'
+import FlexBox from '@/components/flex-box'
+import IconButton from '@/components/IconButton'
+import PageTitle from '@/components/page-title'
+import UserDisplay from '@/components/user-display'
+import type UserORM from '@/modules/user/types/orms/user'
+
+export default function Page() {
+    const [search, setSearch] = useState('')
+
+    const { data, mutate, isValidating } =
+        useSWR<
+            {
+                name: UserORM['name']
+                id: UserORM['id']
+            }[]
+        >('_/online-users')
+
+    if (!data) return null
+
+    const usersFiltered = data.filter(user => {
+        return user.name.toLowerCase().includes(search.toLowerCase())
+    })
+
+    return (
+        <>
+            <PageTitle title="Pengguna Online" />
+
+            <FlexBox>
+                <TextField
+                    fullWidth
+                    label="Cari"
+                    onChange={e => setSearch(e.target.value)}
+                    size="small"
+                />
+
+                <IconButton
+                    icon={RefreshIcon}
+                    onClick={() => mutate()}
+                    title="Segarkan"
+                />
+            </FlexBox>
+
+            {isValidating && <LinearProgress color="success" />}
+
+            <p>{usersFiltered.length} pengguna online</p>
+
+            <ul>
+                {usersFiltered.map(user => (
+                    <li key={user.id}>
+                        <UserDisplay data={user} />
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}

--- a/src/app/(auth)/dashboard/cards.tsx
+++ b/src/app/(auth)/dashboard/cards.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import useSWR from 'swr'
+import BigNumberCard, {
+    type BigNumberCardProps,
+} from '@/components/big-number-card'
+import TopLoadingBar from '@/components/top-loading-bar'
+import RoleEnum from '@/enums/role'
+import useIsAuthHasRole from '@/hooks/use-is-auth-has-role'
+
+export function Cards() {
+    const isAuthHasRole = useIsAuthHasRole()
+
+    const { data = [], isValidating } = useSWR<BigNumberCardProps[]>(
+        isAuthHasRole(RoleEnum.SUPERMAN) ? 'data/dashboard' : null,
+    )
+
+    return (
+        <>
+            {isValidating && <TopLoadingBar />}
+
+            {data.map((item, index) => (
+                <BigNumberCard key={index} {...item} />
+            ))}
+        </>
+    )
+}

--- a/src/app/(auth)/dashboard/greetings.tsx
+++ b/src/app/(auth)/dashboard/greetings.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import Skeleton from '@mui/material/Skeleton'
+import Typography from '@mui/material/Typography'
+import useAuthInfo from '@/hooks/use-auth-info'
+
+export default function Greeting() {
+    const user = useAuthInfo()
+
+    return (
+        <Typography component="div" mb={4} variant="h5">
+            Selamat datang,{' '}
+            {user?.name ? (
+                <Typography color="info.main" component="span" variant="h5">
+                    {user?.name}
+                </Typography>
+            ) : (
+                <Skeleton
+                    component="span"
+                    height="2rem"
+                    variant="rounded"
+                    width="7rem"
+                />
+            )}
+        </Typography>
+    )
+}

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -1,106 +1,33 @@
-'use client'
-
-// icons-materials
-import FireTruck from '@mui/icons-material/FireTruck'
-import Forest from '@mui/icons-material/Forest'
-// materials
-import Box from '@mui/material/Box'
 import Grid from '@mui/material/Grid'
-import Skeleton from '@mui/material/Skeleton'
-import Typography from '@mui/material/Typography'
-// vendors
-import useSWR from 'swr'
-import BigNumberCard, {
-    type BigNumberCardProps,
-} from '@/components/big-number-card'
+import type { Metadata } from 'next'
+import FlexBox from '@/components/flex-box'
 import AlertListCard from '@/components/pages/dashboard/AlertListCard'
-// components
-import ScrollableXBox from '@/components/ScrollableXBox'
-// enums
-import Role from '@/enums/role'
-// hooks
-import useAuthInfo from '@/hooks/use-auth-info'
-import useIsAuthHasRole from '@/hooks/use-is-auth-has-role'
-import type ApiResponseType from '../me/participation/api-response-type'
+import { Cards } from './cards'
+import Greeting from './greetings'
+import TempCards from './temp-cards'
 
-/**
- * The `Page` component represents the dashboard page of the application.
- * It fetches user-specific data and displays various sections based on the user's role.
- *
- * @todo Add total participation (RP) section
- */
 export default function Page() {
-    const user = useAuthInfo()
-    const isAuthHasRole = useIsAuthHasRole()
-
-    const { data: { palmBunchesDelivery, palmBunches } = {} } =
-        useSWR<ApiResponseType>(
-            isAuthHasRole([Role.FARMER, Role.COURIER])
-                ? 'me/participations'
-                : null,
-        )
-
-    const { data = [] } = useSWR<BigNumberCardProps[]>(
-        isAuthHasRole([Role.SUPERMAN]) ? 'data/dashboard' : null,
-    )
-
     return (
         <>
-            <Typography component="div" mb={4} variant="h5">
-                Selamat datang,{' '}
-                {user?.name ? (
-                    <Typography color="info.main" component="span" variant="h5">
-                        {user?.name}
-                    </Typography>
-                ) : (
-                    <Skeleton
-                        component="span"
-                        height="2rem"
-                        variant="rounded"
-                        width="7rem"
-                    />
-                )}
-            </Typography>
+            <Greeting />
 
-            <ScrollableXBox
-                alignItems="stretch"
-                flex="1 1 0"
-                gap={3}
-                mb={6}
+            <FlexBox
+                alignItems="flex-start"
+                gap={2}
+                mt={8}
                 sx={{
-                    '& > *': {
-                        flex: '0 0 auto',
-                        minWidth: '15rem',
+                    '> *': {
+                        flexBasis: {
+                            md: '32%',
+                            xs: '100%',
+                        },
+                        height: '100%',
                     },
+                    flexFlow: 'row wrap',
                 }}>
-                {isAuthHasRole(Role.FARMER) && palmBunches && (
-                    <BigNumberCard
-                        {...palmBunches.bigNumber1}
-                        title={
-                            <Box alignItems="center" display="flex" gap={2}>
-                                <Forest />
-                                <div>Penjualan TBS bulan ini</div>
-                            </Box>
-                        }
-                    />
-                )}
-
-                {isAuthHasRole(Role.COURIER) && palmBunchesDelivery && (
-                    <BigNumberCard
-                        {...palmBunchesDelivery.bigNumber1}
-                        title={
-                            <Box alignItems="center" display="flex" gap={2}>
-                                <FireTruck />
-                                <div>Pengangkutan TBS bulan ini</div>
-                            </Box>
-                        }
-                    />
-                )}
-
-                {data.map((item, index) => (
-                    <BigNumberCard key={index} {...item} />
-                ))}
-            </ScrollableXBox>
+                <TempCards />
+                <Cards />
+            </FlexBox>
 
             <Grid container spacing={2}>
                 <Grid size={{ md: 4, xs: 12 }}>
@@ -109,4 +36,8 @@ export default function Page() {
             </Grid>
         </>
     )
+}
+
+export const metadata: Metadata = {
+    title: `Dasbor — ${process.env.NEXT_PUBLIC_APP_NAME}`,
 }

--- a/src/app/(auth)/dashboard/temp-cards.tsx
+++ b/src/app/(auth)/dashboard/temp-cards.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+// icons-materials
+import FireTruck from '@mui/icons-material/FireTruck'
+import Forest from '@mui/icons-material/Forest'
+// materials
+import Box from '@mui/material/Box'
+// vendors
+import useSWR from 'swr'
+import BigNumberCard from '@/components/big-number-card'
+// enums
+import Role from '@/enums/role'
+// hooks
+import useIsAuthHasRole from '@/hooks/use-is-auth-has-role'
+import type ApiResponseType from '../me/participation/api-response-type'
+
+/**
+ * The `Page` component represents the dashboard page of the application.
+ * It fetches user-specific data and displays various sections based on the user's role.
+ *
+ * @todo Add total participation (RP) section
+ */
+export default function TempCards() {
+    const isAuthHasRole = useIsAuthHasRole()
+
+    const { data: { palmBunchesDelivery, palmBunches } = {} } =
+        useSWR<ApiResponseType>(
+            isAuthHasRole([Role.FARMER, Role.COURIER])
+                ? 'me/participations'
+                : null,
+        )
+
+    return (
+        <>
+            {isAuthHasRole(Role.FARMER) && palmBunches && (
+                <BigNumberCard
+                    {...palmBunches.bigNumber1}
+                    title={
+                        <Box alignItems="center" display="flex" gap={2}>
+                            <Forest />
+                            <div>Penjualan TBS bulan ini</div>
+                        </Box>
+                    }
+                />
+            )}
+
+            {isAuthHasRole(Role.COURIER) && palmBunchesDelivery && (
+                <BigNumberCard
+                    {...palmBunchesDelivery.bigNumber1}
+                    title={
+                        <Box alignItems="center" display="flex" gap={2}>
+                            <FireTruck />
+                            <div>Pengangkutan TBS bulan ini</div>
+                        </Box>
+                    }
+                />
+            )}
+        </>
+    )
+}

--- a/src/components/auth-layout/_parts/nav-bar/NAV_ITEM_GROUPS/supermans.ts
+++ b/src/components/auth-layout/_parts/nav-bar/NAV_ITEM_GROUPS/supermans.ts
@@ -5,6 +5,7 @@ import Biotech from '@mui/icons-material/Biotech'
 import Group from '@mui/icons-material/Group'
 import TicketIcon from '@mui/icons-material/LocalActivity'
 import Note from '@mui/icons-material/Note'
+import OnlinePrediction from '@mui/icons-material/OnlinePrediction'
 import PrintIcon from '@mui/icons-material/Print'
 import SupervisedUserCircle from '@mui/icons-material/SupervisedUserCircle'
 // enums
@@ -48,6 +49,13 @@ export const supermans: NavItemGroup = {
             href: '/print-test',
             icon: PrintIcon,
             label: 'Test Cetak',
+        },
+
+        {
+            forRole: Role.SUPERMAN,
+            href: '/online-users',
+            icon: OnlinePrediction,
+            label: 'Pengguna Online',
         },
     ],
     label: 'Superman',

--- a/src/components/top-loading-bar.tsx
+++ b/src/components/top-loading-bar.tsx
@@ -1,0 +1,16 @@
+import LinearProgress from '@mui/material/LinearProgress'
+
+export default function TopLoadingBar() {
+    return (
+        <LinearProgress
+            color="success"
+            sx={{
+                left: 0,
+                position: 'fixed',
+                right: 0,
+                top: 0,
+                zIndex: 1202, // theme.zIndex.drawer + 1
+            }}
+        />
+    )
+}


### PR DESCRIPTION
Extracts dashboard sections into dedicated components (`Greeting`, `Cards`, `TempCards`) to improve modularity and maintainability. This separates role-based card displays and cleans up `dashboard/page.tsx`.

Introduces a new "Online Users" page, allowing administrators to view, search, and refresh a list of currently active users.

Adds a global `TopLoadingBar` component for a consistent loading indication.

Updates the Superman navigation to include the new "Pengguna Online" link.