### PR TITLE
Enhances spare part adjustment displays

### DIFF
--- a/src/app/(auth)/repair-shop/spare-part-qty-adjustments/[uuid]/detail-table.tsx
+++ b/src/app/(auth)/repair-shop/spare-part-qty-adjustments/[uuid]/detail-table.tsx
@@ -41,6 +41,7 @@ export default function DetailTable({
                 <TableHead>
                     <TableRow>
                         <TableCell>#</TableCell>
+                        <TableCell>ID</TableCell>
                         <TableCell>Kode</TableCell>
                         <TableCell>Nama</TableCell>
                         <TableCell align="right">HPP Satuan</TableCell>
@@ -105,7 +106,7 @@ function Footer({ data }: { data: SparePartMovementORM['details'] }) {
     return (
         <TableFooter>
             <TableRow>
-                <TableCell align="right" colSpan={7}>
+                <TableCell align="right" colSpan={8}>
                     TOTAL
                 </TableCell>
 
@@ -141,6 +142,7 @@ const DetailRow = memo(function DetailRow({
                 },
             }}>
             <TableCell>{formatNumber(index + 1)}</TableCell>
+            <TableCell>{spare_part_state.id}</TableCell>
             <TableCell>{displayCode}</TableCell>
             <TableCell>{spare_part_state.name}</TableCell>
             <TableCell align="right">

--- a/src/app/(auth)/repair-shop/spare-part-qty-adjustments/page.tsx
+++ b/src/app/(auth)/repair-shop/spare-part-qty-adjustments/page.tsx
@@ -140,6 +140,11 @@ const columns: DatatableProps<SparePartMovementORM>['columns'] = [
         label: 'Ditemukan (Rp)',
         name: 'found_rp',
         options: {
+            customBodyRender: value =>
+                formatNumber(value ?? 0, {
+                    compactDisplay: 'short',
+                    notation: 'compact',
+                }),
             searchable: false,
             setCellProps: () => ({
                 sx: { textAlign: 'right' },
@@ -152,6 +157,11 @@ const columns: DatatableProps<SparePartMovementORM>['columns'] = [
         label: 'Hilang (Rp)',
         name: 'lost_rp',
         options: {
+            customBodyRender: value =>
+                formatNumber(value ?? 0, {
+                    compactDisplay: 'short',
+                    notation: 'compact',
+                }),
             searchable: false,
             setCellProps: () => ({
                 sx: { textAlign: 'right' },
@@ -162,8 +172,13 @@ const columns: DatatableProps<SparePartMovementORM>['columns'] = [
 
     {
         label: 'Selisih (Rp)',
-        name: 'sum_value_rp',
+        name: 'diff_rp',
         options: {
+            customBodyRender: value =>
+                formatNumber(value ?? 0, {
+                    compactDisplay: 'short',
+                    notation: 'compact',
+                }),
             searchable: false,
             setCellProps: () => ({
                 sx: { textAlign: 'right' },


### PR DESCRIPTION
Adds spare part ID to the detail table, improving traceability for individual spare parts.

Updates the main listing page to format monetary values (found, lost, and difference amounts) compactly for better readability. Also renames the 'Sum Value' column to 'Difference' for clarity.