### PR TITLE
Adds 'Kategori' column to spare parts datatable

### DIFF
--- a/src/app/(auth)/repair-shop/spare-parts/page-client.tsx
+++ b/src/app/(auth)/repair-shop/spare-parts/page-client.tsx
@@ -132,6 +132,10 @@ const DATATABLE_COLUMNS: DatatableProps<SparePart>['columns'] = [
         name: 'name',
     },
     {
+        label: 'Kategori',
+        name: 'category',
+    },
+    {
         label: 'Jenis Kendaraan',
         name: 'vehicle_type',
         options: {


### PR DESCRIPTION
Enhances data visibility by displaying the category for each spare part directly in the table.